### PR TITLE
Moved rate-limiting-merged plugin registration from hard-coded to values.yaml

### DIFF
--- a/templates/_kong.tpl
+++ b/templates/_kong.tpl
@@ -670,7 +670,7 @@ false
 {{ $enabledPlugins = printf "%s,%s" $enabledPlugins "cequence-ai-unified" }}
 {{- end }}
 - name: KONG_PLUGINS
-  value: bundled,jwt-keycloak,rate-limiting-merged{{ $enabledPlugins }}
+  value: bundled,jwt-keycloak{{ $enabledPlugins }}
 - name: KONG_LUA_PACKAGE_PATH
   value: "/opt/?.lua;;"
 {{- end -}}

--- a/values.yaml
+++ b/values.yaml
@@ -263,7 +263,8 @@ setupJobs:
   #containerSecurityContext: {}
 
 plugins:
-  enabled: []
+  enabled:
+    - rate-limiting-merged
 
   acl:
     pluginId: bc823d55-83b5-4184-b03f-ce63cd3b75c7


### PR DESCRIPTION
This PR decouples the open sourced Kong version from the not yet open-sourced rate-limiting-merged plugin.