### PR TITLE
fix: make db port configurable for bootstrap and migration jobs

### DIFF
--- a/templates/_kong.tpl
+++ b/templates/_kong.tpl
@@ -444,6 +444,8 @@ false
 {{- define "kong.migrations.checkdatabase.env" }}
 - name: PGHOST
   value: {{ include "database.host" $ }}
+- name: PGPORT
+  value: {{ .Values.global.database.port | default "5432" | quote }}
 - name: PGDATABASE
   value: {{ .Values.global.database.database }}
 - name: PGUSER


### PR DESCRIPTION
Added configurable db port environment variable with default value used in Kong bootstrap and migration jobs to account for non-standard postgres port.