### PR TITLE
feat: introduce argo rollouts

### DIFF
--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -409,6 +409,125 @@ For a complete configuration example with all available options, see the `values
 - [KEDA Scalers](https://keda.sh/docs/scalers/)
 - [Victoria Metrics PromQL](https://docs.victoriametrics.com/MetricsQL.html)
 
+### Argo Rollouts (Progressive Delivery - BETA)
+
+**Available since chart version `8.1.0`**
+
+Please note that the helm value api is in early state and values as well as templates are suspect to change, which might break your configuration.
+
+[Argo Rollouts](https://argoproj.github.io/rollouts/) provides advanced deployment capabilities with progressive delivery strategies like canary and blue-green deployments. When enabled, Argo Rollouts manages the rollout process while maintaining the existing Deployment resource through `workloadRef`.
+
+**Features:**
+- **Canary Deployments**: Gradually shift traffic from stable to new version with configurable steps
+- **Blue-Green Deployments**: Run two identical production environments (blue and green)
+- **Automated Analysis**: Optional metric-based validation using Prometheus/Victoria Metrics
+- **Traffic Management**: NGINX Ingress-based traffic splitting with canary annotations
+- **Automated Rollbacks**: Automatic rollback based on analysis metrics (error rate, success rate)
+
+**Prerequisites:**
+- Argo Rollouts must be installed in the cluster: `kubectl create namespace argo-rollouts && kubectl apply -n argo-rollouts -f https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml`
+- NGINX Ingress Controller (for traffic routing)
+- Prometheus/Victoria Metrics (optional, for automated analysis)
+
+**Important:** `argoRollouts` and `hpaAutoscaling` (HPA) are mutually exclusive. KEDA autoscaling can be used together with Argo Rollouts.
+
+**Minimal Configuration Example** (Canary without analysis):
+
+```yaml
+argoRollouts:
+  enabled: true
+  
+  strategy:
+    type: canary
+    canary:
+      steps:
+        - setWeight: 10
+        - pause:
+            duration: 2m
+        - setWeight: 50
+        - pause:
+            duration: 5m
+```
+
+**Advanced Configuration Example** (Canary with automated analysis):
+
+```yaml
+argoRollouts:
+  enabled: true
+  
+  strategy:
+    type: canary
+    canary:
+      additionalProperties:
+        maxUnavailable: "50%"
+        maxSurge: "25%"
+        scaleDownDelaySeconds: 60
+      
+      steps:
+        - setWeight: 10
+        - pause:
+            duration: 2m
+        - setWeight: 50
+        - pause:
+            duration: 5m
+      
+      analysis:
+        templates:
+          - templateName: success-rate-analysis
+        startingStep: 1
+  
+  analysisTemplates:
+    enabled: true
+    
+    successRate:
+      enabled: true
+      interval: 30s
+      count: 0
+      failureLimit: 3
+      successCondition: "all(result, # >= 0.95)"
+      prometheusAddress: "http://prometheus.monitoring.svc.cluster.local:8427"
+      authentication:
+        enabled: true
+        secretName: "victoria-metrics-secret"
+        basicKey: "basic-auth"
+```
+
+**Blue-Green Deployment Example**:
+
+```yaml
+argoRollouts:
+  enabled: true
+  
+  strategy:
+    type: blueGreen
+    blueGreen:
+      autoPromotionEnabled: false    # Manual promotion required
+      scaleDownDelaySeconds: 30      # Wait before scaling down old version
+      prePromotionAnalysis:          # Optional: analysis before promotion
+        templates:
+          - templateName: success-rate-analysis
+```
+
+**Key Configuration Options:**
+
+| Helm-Chart variable                                    | Description                                           | Default  |
+|--------------------------------------------------------|-------------------------------------------------------|----------|
+| `argoRollouts.enabled`                                 | Enable Argo Rollouts progressive delivery             | `false`  |
+| `argoRollouts.strategy.type`                           | Strategy type: "canary" or "blueGreen"                | `canary` |
+| `argoRollouts.strategy.canary.steps`                   | Canary rollout steps (weight, pause, analysis)        | See docs |
+| `argoRollouts.strategy.canary.analysis.startingStep`   | Step at which to start background analysis            | (unset)  |
+| `argoRollouts.strategy.blueGreen`                      | Blue-green strategy configuration (autoPromotionEnabled, scaleDownDelaySeconds, etc.) | See docs |
+| `argoRollouts.analysisTemplates.enabled`               | Enable automated analysis templates                   | `true`   |
+| `argoRollouts.analysisTemplates.errorRate.enabled`     | Enable error rate analysis                            | `true`   |
+| `argoRollouts.analysisTemplates.successRate.enabled`   | Enable success rate analysis                          | `true`   |
+
+For detailed configuration, examples, and troubleshooting, see the [Argo Rollouts Feature Documentation](docs/ARGO_ROLLOUTS_FEATURE.md).
+
+**References:**
+- [Argo Rollouts Documentation](https://argoproj.github.io/rollouts/)
+- [Argo Rollouts Canary Strategy](https://argoproj.github.io/rollouts/features/canary/)
+- [Argo Rollouts Analysis](https://argoproj.github.io/rollouts/features/analysis/)
+
 ### PodAntiaffinity & TopologyKey
 
 In Kubernetes it is recommended to distribute the pods over several nodes. If a kubernetes node gets into problems, there are enough pods on other nodes to take on the load.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -4,7 +4,7 @@ SPDX-PackageSupplier = "Deutsche Telekom AG <opensource@telekom.de>"
 SPDX-PackageDownloadLocation = "https://github.com/telekom/gateway-kong-chart"
 
 [[annotations]]
-path = ["CHANGELOG.md"]
+path = ["CHANGELOG.md", "docs/*.md"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "Copyright 2025 Deutsche Telekom AG"
 SPDX-License-Identifier = "CC0-1.0"

--- a/docs/ARGO_ROLLOUTS_FEATURE.md
+++ b/docs/ARGO_ROLLOUTS_FEATURE.md
@@ -1,0 +1,461 @@
+# Argo Rollouts Feature Documentation
+
+## Overview
+
+This Helm chart supports **Argo Rollouts** for progressive delivery with canary and blue-green deployments. When enabled, the chart deploys:
+
+1. **Rollout Resource** - Manages the deployment with progressive delivery using `workloadRef` to the existing Deployment
+2. **Canary Service** - Additional service for routing canary traffic (`{{ .Release.Name }}-proxy-canary`)
+3. **AnalysisTemplates** - Automated metric-based validation for rollout decisions (optional)
+
+## Prerequisites
+
+- Argo Rollouts must be installed in the cluster
+- NGINX Ingress Controller (for traffic routing with canary)
+- Prometheus/Victoria Metrics accessible for analysis (optional, required if using AnalysisTemplates)
+- Kubernetes secret containing Prometheus credentials (if using authentication for metrics)
+
+## Configuration
+
+### Enable Argo Rollouts
+
+Set in your `values.yaml`:
+
+```yaml
+argoRollouts:
+  enabled: true
+  
+  analysisTemplates:
+    errorRate:
+      prometheusAddress: "http://prometheus.monitoring.svc.cluster.local:8427"
+    successRate:
+      prometheusAddress: "http://prometheus.monitoring.svc.cluster.local:8427"
+```
+
+### Resources Created
+
+When `argoRollouts.enabled=true`, the following resources are deployed:
+
+#### 1. Rollout Resource (`templates/rollout-kong.yaml`)
+- Uses `workloadRef` to manage the existing Deployment resource
+- Implements canary or blue-green strategy with configurable traffic shifting
+- References AnalysisTemplates for automated validation (optional)
+- Uses NGINX Ingress for traffic routing via canary annotations
+
+#### 2. Canary Service (`templates/service-proxy-canary.yml`)
+- Service: `{{ .Release.Name }}-proxy-canary`
+- Routes canary traffic during progressive rollout
+- Same selector as stable service (`{{ .Release.Name }}-proxy`)
+
+#### 3. AnalysisTemplates (`templates/analysistemplate-kong.yaml`) - Optional
+- **error-rate-analysis**: Monitors HTTP error rate via NGINX Ingress metrics
+- **success-rate-analysis**: Monitors overall success rate via NGINX Ingress metrics
+- Triggers automatic rollback on failure
+- Enabled via `argoRollouts.analysisTemplates.enabled=true`
+
+## Default Canary Strategy
+
+The default configuration implements a simple canary rollout:
+
+```yaml
+argoRollouts:
+  enabled: false
+  
+  strategy:
+    type: canary
+    canary:
+      additionalProperties:
+        maxUnavailable: "50%"
+        maxSurge: "25%"
+        scaleDownDelaySeconds: 60
+      
+      steps:
+        - setWeight: 10      # Route 10% traffic to canary
+        - pause:
+            duration: 2m     # Wait 2 minutes
+        # Automatic promotion to 100%
+      
+      analysis:
+        templates:
+          - templateName: success-rate-analysis
+        args: []
+        startingStep:  # Optional: define at which step to start analysis (1-based index)
+```
+
+The Rollout uses NGINX Ingress traffic routing with canary annotations (`canary-by-header: x-canary`) to gradually shift traffic from stable to canary versions.
+
+## Analysis Templates
+
+Analysis templates are **optional** and use NGINX Ingress Controller metrics. Enable them with:
+
+```yaml
+argoRollouts:
+  analysisTemplates:
+    enabled: true
+```
+
+### Error Rate Analysis
+
+Monitors HTTP error rate (4xx/5xx) from NGINX Ingress metrics and triggers rollback if > 5%:
+
+```yaml
+errorRate:
+  enabled: true
+  interval: 30s
+  count: 0
+  failureLimit: 2
+  successCondition: "all(result, # < 0.05)"
+  query: |
+    sum(irate(
+      nginx_ingress_controller_request_duration_seconds_count{
+        exported_namespace="{{`{{ args.namespace }}`}}",
+        exported_service="{{`{{ args.service-name }}`}}",
+        ingress="{{`{{ args.service-name }}`}}",
+        canary!="",
+        status!~"5.."
+      }[1m]
+    )) /
+    sum(irate(
+      nginx_ingress_controller_request_duration_seconds_count{
+        exported_namespace="{{`{{ args.namespace }}`}}",
+        exported_service="{{`{{ args.service-name }}`}}",
+        ingress="{{`{{ args.service-name }}`}}",
+        canary!=""
+      }[1m]
+    ))
+  prometheusAddress: ""  # Required: set your Prometheus/Victoria Metrics URL
+```
+
+### Success Rate Analysis
+
+Monitors overall success rate from NGINX Ingress metrics and triggers rollback if < 95%:
+
+```yaml
+successRate:
+  enabled: true
+  interval: 30s
+  count: 0
+  failureLimit: 3
+  successCondition: "all(result, # >= 0.95)"
+  query: |
+    sum(irate(
+      nginx_ingress_controller_request_duration_seconds_count{
+        exported_namespace="{{`{{ args.namespace }}`}}",
+        exported_service="{{`{{ args.service-name }}`}}",
+        ingress="{{`{{ args.service-name }}`}}",
+        canary!="",
+        status!~"(4|5).*"
+      }[1m]
+    )) /
+    sum(irate(
+      nginx_ingress_controller_request_duration_seconds_count{
+        exported_namespace="{{`{{ args.namespace }}`}}",
+        exported_service="{{`{{ args.service-name }}`}}",
+        ingress="{{`{{ args.service-name }}`}}",
+        canary!=""
+      }[1m]
+    ))
+  prometheusAddress: ""  # Required: set your Prometheus/Victoria Metrics URL
+```
+
+**Note:** Both templates use NGINX Ingress Controller metrics (`nginx_ingress_controller_request_duration_seconds_count`) and require `prometheusAddress` to be configured.
+
+## Authentication Setup
+
+### Creating the Prometheus Secret
+
+If your Prometheus/Victoria Metrics endpoint requires authentication, create a secret in the same namespace as your Rollout with a base64-encoded `basic-auth` key:
+
+```bash
+# Create base64 encoded user:password for Basic Auth
+echo -n 'your-username:your-password' | base64
+
+# Create the secret
+kubectl create secret generic victoria-metrics-secret \
+  --from-literal=basic-auth='<base64-encoded-user:password>' \
+  --namespace=<your-namespace>
+```
+
+Or using a YAML manifest:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: victoria-metrics-secret
+  namespace: <your-namespace>
+type: Opaque
+data:
+  basic-auth: "<base64-encoded-user:password>"  # e.g., dXNlcjpwYXNzd29yZA==
+```
+
+The chart will use this secret for Basic Auth headers when querying Prometheus/Victoria Metrics.
+
+### Disabling Authentication
+
+If your Prometheus endpoint doesn't require authentication, disable it in your `values.yaml`:
+
+```yaml
+argoRollouts:
+  analysisTemplates:
+    errorRate:
+      authentication:
+        enabled: false
+    successRate:
+      authentication:
+        enabled: false
+```
+
+## Customization
+
+### Customize Canary Steps
+
+Override the default steps in your `values.yaml`:
+
+```yaml
+argoRollouts:
+  strategy:
+    type: canary
+    canary:
+      steps:
+        - setWeight: 20
+        - pause:
+            duration: 10m
+        - setWeight: 50
+        - pause:
+            duration: 10m
+        - setWeight: 100
+```
+
+### Customize Blue-Green Strategy
+
+Configure blue-green deployment behavior:
+
+```yaml
+argoRollouts:
+  strategy:
+    type: blueGreen
+    blueGreen:
+      autoPromotionEnabled: true
+      autoPromotionSeconds: 300  # Auto-promote after 5 minutes if analysis succeeds
+      scaleDownDelaySeconds: 30
+      previewReplicaCount: 1     # Run only 1 replica for preview
+      prePromotionAnalysis:
+        templates:
+          - templateName: success-rate-analysis
+          - templateName: error-rate-analysis
+```
+
+### Customize Analysis Thresholds
+
+```yaml
+argoRollouts:
+  analysisTemplates:
+    enabled: true
+    
+    errorRate:
+      enabled: true
+      interval: 1m
+      count: 0
+      failureLimit: 2
+      successCondition: "all(result, # < 0.05)"  # 5% error threshold
+      prometheusAddress: "http://prometheus.monitoring.svc.cluster.local:8427"
+      authentication:
+        enabled: true
+        secretName: "victoria-metrics-secret"
+        basicKey: "basic-auth"
+    
+    successRate:
+      enabled: true
+      interval: 2m
+      count: 0
+      failureLimit: 3
+      successCondition: "all(result, # >= 0.95)"  # 95% success threshold
+      prometheusAddress: "http://prometheus.monitoring.svc.cluster.local:8427"
+      authentication:
+        enabled: true
+        secretName: "victoria-metrics-secret"
+        basicKey: "basic-auth"
+```
+
+### Disable Analysis Templates
+
+```yaml
+argoRollouts:
+  analysisTemplates:
+    enabled: false
+```
+
+## Compatibility with Autoscaling
+
+- **HPA (Horizontal Pod Autoscaler)**: `hpaAutoscaling.enabled` must be `false` when using Argo Rollouts
+- **KEDA Autoscaling**: Can be used with Argo Rollouts - KEDA manages replica count, Argo Rollouts manages progressive delivery
+
+The chart validates these constraints via the `argoRollouts.validate` helper and will fail with a clear error message if HPA is enabled together with Argo Rollouts.
+
+## Testing
+
+Test the templates with the preprod values file:
+
+```bash
+# Test Rollout resource
+helm template test-release . -f values-preprod.yaml \
+  --set argoRollouts.enabled=true \
+  --set argoRollouts.analysisTemplates.errorRate.prometheusAddress=http://test:8427 \
+  --set argoRollouts.analysisTemplates.successRate.prometheusAddress=http://test:8427 \
+  --show-only templates/rollout-kong.yaml
+
+# Test canary service
+helm template test-release . -f values-preprod.yaml \
+  --set argoRollouts.enabled=true \
+  --show-only templates/service-proxy-canary.yml
+
+# Test analysis templates
+helm template test-release . -f values-preprod.yaml \
+  --set argoRollouts.enabled=true \
+  --set argoRollouts.analysisTemplates.errorRate.prometheusAddress=http://test:8427 \
+  --set argoRollouts.analysisTemplates.successRate.prometheusAddress=http://test:8427 \
+  --show-only templates/analysistemplate-kong.yaml
+```
+
+## Files Added/Modified
+
+### New Files
+- `templates/rollout-kong.yaml` - Rollout resource with workloadRef
+- `templates/rollout-kong.yaml.license` - License header
+- `templates/service-proxy-canary.yml` - Canary service
+- `templates/service-proxy-canary.yml.license` - License header
+- `templates/analysistemplate-kong.yaml` - Analysis templates
+- `templates/analysistemplate-kong.yaml.license` - License header
+- `templates/_argo-rollouts.tpl` - Helper templates
+- `templates/_argo-rollouts.tpl.license` - License header
+
+### Modified Files
+- `values.yaml` - Added `argoRollouts` configuration section
+- `templates/deployment-kong.yml` - Added validation and replica management for Argo Rollouts
+
+## Example Configuration
+
+Complete example for production use with canary deployment:
+
+```yaml
+argoRollouts:
+  enabled: true
+  
+  strategy:
+    type: canary
+    canary:
+      additionalProperties:
+        maxUnavailable: "50%"
+        maxSurge: "25%"
+        scaleDownDelaySeconds: 60
+      
+      steps:
+        - setWeight: 10
+        - pause:
+            duration: 2m
+        - setWeight: 25
+        - pause:
+            duration: 3m
+        - setWeight: 50
+        - pause:
+            duration: 5m
+        - setWeight: 75
+        - pause:
+            duration: 5m
+      
+      analysis:
+        templates:
+          - templateName: success-rate-analysis
+        args: []
+        startingStep: 1  # Start analysis after first step
+  
+  analysisTemplates:
+    enabled: true
+    
+    errorRate:
+      enabled: true
+      interval: 30s
+      count: 0
+      failureLimit: 2
+      successCondition: "all(result, # < 0.05)"
+      prometheusAddress: "http://prometheus.monitoring.svc.cluster.local:8427"
+      authentication:
+        enabled: true
+        secretName: "victoria-metrics-secret"
+        basicKey: "basic-auth"
+    
+    successRate:
+      enabled: true
+      interval: 30s
+      count: 0
+      failureLimit: 3
+      successCondition: "all(result, # >= 0.95)"
+      prometheusAddress: "http://prometheus.monitoring.svc.cluster.local:8427"
+      authentication:
+        enabled: true
+        secretName: "victoria-metrics-secret"
+        basicKey: "basic-auth"
+```
+
+### Example: Blue-Green Deployment
+
+Blue-green deployment runs two identical production environments. Only one (blue or green) serves production traffic while the other is idle or used for staging.
+
+```yaml
+argoRollouts:
+  enabled: true
+  
+  strategy:
+    type: blueGreen
+    blueGreen:
+      # Automatic promotion disabled - requires manual approval
+      autoPromotionEnabled: false
+      
+      # Time to wait before scaling down the old version after promotion
+      scaleDownDelaySeconds: 30
+      
+      # Optional: Run analysis before promoting preview to active
+      prePromotionAnalysis:
+        templates:
+          - templateName: success-rate-analysis
+      
+      # Optional: Run analysis after promotion
+      postPromotionAnalysis:
+        templates:
+          - templateName: success-rate-analysis
+```
+
+**How it works:**
+1. New version deploys to preview service (`{{ .Release.Name }}-proxy-canary`)
+2. Active service (`{{ .Release.Name }}-proxy`) continues serving production traffic
+3. Optional pre-promotion analysis validates the preview version
+4. Manual or automatic promotion switches traffic to the new version
+5. Optional post-promotion analysis validates the promotion
+6. Old version scales down after `scaleDownDelaySeconds`
+
+**Note:** The `activeService` and `previewService` are automatically set by the template to `{{ .Release.Name }}-proxy` and `{{ .Release.Name }}-proxy-canary` respectively. All other blue-green configuration options can be customized via `argoRollouts.strategy.blueGreen`.
+
+**Common Blue-Green Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `autoPromotionEnabled` | Automatically promote to active after successful analysis | `false` |
+| `scaleDownDelaySeconds` | Seconds to wait before scaling down old version | (unset) |
+| `prePromotionAnalysis` | AnalysisTemplate to run before promotion | (unset) |
+| `postPromotionAnalysis` | AnalysisTemplate to run after promotion | (unset) |
+| `previewReplicaCount` | Number of replicas for preview (defaults to spec.replicas) | (unset) |
+| `autoPromotionSeconds` | Time to wait before auto-promotion (requires autoPromotionEnabled) | (unset) |
+
+## Important Notes
+
+- **workloadRef Strategy**: The Rollout uses `workloadRef` to manage the existing Deployment, allowing Argo Rollouts to control progressive delivery without replacing the Deployment resource
+- **Replica Management**: When `argoRollouts.enabled=true` and KEDA is disabled, the Rollout manages replica count. If KEDA is enabled, KEDA manages replicas and the Rollout manages progressive delivery
+- **Traffic Routing**: 
+  - **Canary**: Uses NGINX Ingress Controller with canary annotations for traffic splitting. The header `x-canary` can be used to force traffic to canary version
+  - **Blue-Green**: Traffic switches between active (`{{ .Release.Name }}-proxy`) and preview (`{{ .Release.Name }}-proxy-canary`) services
+- **Analysis Templates**: Optional feature that requires Prometheus/Victoria Metrics. Metrics are sourced from NGINX Ingress Controller. Can be used with both canary and blue-green strategies
+- **Authentication**: Analysis templates use Basic Auth with base64-encoded credentials stored in Kubernetes secrets
+- **Namespace**: All resources (Rollout, Services, AnalysisTemplates, Secrets) must be in the same namespace
+- **ScaleDown**: The Rollout is configured with `scaleDown: onsuccess` to clean up old ReplicaSets after successful rollout
+- **Blue-Green Services**: The `activeService` and `previewService` are automatically configured and should not be overridden. Configure other blue-green options via `argoRollouts.strategy.blueGreen`

--- a/templates/_argo-rollouts.tpl
+++ b/templates/_argo-rollouts.tpl
@@ -1,0 +1,22 @@
+{{/*
+Argo Rollouts helper templates for the stargate chart
+*/}}
+
+{{/*
+Validates Argo Rollouts configuration
+*/}}
+{{- define "argoRollouts.validate" -}}
+{{- if .Values.argoRollouts.enabled }}
+  {{- if and .Values.hpaAutoscaling.enabled }}
+    {{- fail "argoRollouts.enabled and hpaAutoscaling.enabled cannot both be true. Please disable one." }}
+  {{- end }}
+  {{- if .Values.argoRollouts.analysisTemplates.enabled }}
+    {{- if and .Values.argoRollouts.analysisTemplates.errorRate.enabled (not .Values.argoRollouts.analysisTemplates.errorRate.prometheusAddress) }}
+      {{- fail "argoRollouts.analysisTemplates.errorRate.prometheusAddress is required when error rate analysis is enabled" }}
+    {{- end }}
+    {{- if and .Values.argoRollouts.analysisTemplates.successRate.enabled (not .Values.argoRollouts.analysisTemplates.successRate.prometheusAddress) }}
+      {{- fail "argoRollouts.analysisTemplates.successRate.prometheusAddress is required when success rate analysis is enabled" }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/templates/_argo-rollouts.tpl.license
+++ b/templates/_argo-rollouts.tpl.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 Deutsche Telekom AG
+
+SPDX-License-Identifier: Apache-2.0

--- a/templates/analysistemplate-kong.yaml
+++ b/templates/analysistemplate-kong.yaml
@@ -1,0 +1,128 @@
+{{- if and .Values.argoRollouts.enabled .Values.argoRollouts.analysisTemplates.enabled }}
+{{- include "argoRollouts.validate" . -}}
+---
+# ============================================================================
+# Error Rate Analysis Template
+# ============================================================================
+# Monitors HTTP 5xx error rate during canary rollout
+# Triggers automatic rollback if error rate exceeds threshold
+{{- if .Values.argoRollouts.analysisTemplates.errorRate.enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: {{ .Release.Name }}-error-rate-analysis
+  labels: {{ include "kong.labels" $ | nindent 4 }}
+spec:
+  args:
+    - name: service-name
+      value: {{ .Release.Name }}-proxy
+    - name: namespace
+      value: {{ .Release.Namespace }}
+    {{- if and .Values.argoRollouts.analysisTemplates.errorRate.authentication .Values.argoRollouts.analysisTemplates.errorRate.authentication.enabled }}
+    # Reference credentials from Kubernetes secret for Prometheus authentication
+
+    - name: prometheusBasic
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.argoRollouts.analysisTemplates.errorRate.authentication.secretName }}
+          key: {{ .Values.argoRollouts.analysisTemplates.errorRate.authentication.basicKey }}
+    {{- end }}
+
+  # ============================================================================
+  # Metrics Configuration
+  # ============================================================================
+  metrics:
+  - name: error-rate
+    # -- How often to evaluate the metric
+    interval: {{ .Values.argoRollouts.analysisTemplates.errorRate.interval | default "30s" }}
+    
+    # -- Total number of measurements to take
+    count: {{ .Values.argoRollouts.analysisTemplates.errorRate.count | default 0 }}
+    
+    # -- Number of failures that trigger rollback
+    failureLimit: {{ .Values.argoRollouts.analysisTemplates.errorRate.failureLimit | default 2 }}
+    
+    # -- Success condition (result must be less than threshold)
+    successCondition: {{ .Values.argoRollouts.analysisTemplates.errorRate.successCondition | default "result < 0.05" | quote }}
+    
+    # -- Metric provider configuration (Prometheus)
+    provider:
+      prometheus:
+        # -- Prometheus server address
+        address: {{ .Values.argoRollouts.analysisTemplates.errorRate.prometheusAddress | quote }}
+        
+        # -- PromQL query to calculate error rate
+        query: |
+          {{- tpl .Values.argoRollouts.analysisTemplates.errorRate.query . | nindent 10 }}
+        
+        {{- if and .Values.argoRollouts.analysisTemplates.errorRate.authentication .Values.argoRollouts.analysisTemplates.errorRate.authentication.enabled }}
+        headers:
+          - key: Authorization
+            value: "Basic {{`{{  args.prometheusBasic }}`}}"
+        {{- end }}
+{{- end }}
+---
+# ============================================================================
+# Success Rate Analysis Template
+# ============================================================================
+# Monitors overall HTTP success rate (non-5xx responses) during canary rollout
+# Triggers automatic rollback if success rate falls below threshold
+{{- if .Values.argoRollouts.analysisTemplates.successRate.enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: {{ .Release.Name }}-success-rate-analysis
+  labels: {{ include "kong.labels" $ | nindent 4 }}
+spec:
+  # ============================================================================
+  # Arguments
+  # ============================================================================
+  # Can be passed from Rollout resource for dynamic configuration
+  args:
+  - name: service-name
+    value: {{ .Release.Name }}-proxy
+  - name: namespace
+    value: {{ .Release.Namespace }}
+  {{- if and .Values.argoRollouts.analysisTemplates.successRate.authentication .Values.argoRollouts.analysisTemplates.successRate.authentication.enabled }}
+  # Reference credentials from Kubernetes secret for Prometheus authentication
+  - name: prometheusBasic
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.argoRollouts.analysisTemplates.successRate.authentication.secretName }}
+        key: {{ .Values.argoRollouts.analysisTemplates.successRate.authentication.basicKey }}
+  {{- end }}
+  
+  # ============================================================================
+  # Metrics Configuration
+  # ============================================================================
+  metrics:
+  - name: success-rate
+    # -- How often to evaluate the metric
+    interval: {{ .Values.argoRollouts.analysisTemplates.successRate.interval | default "30s" }}
+    
+    # -- Total number of measurements to take
+    count: {{ .Values.argoRollouts.analysisTemplates.successRate.count | default 0 }}
+    
+    # -- Number of failures that trigger rollback
+    failureLimit: {{ .Values.argoRollouts.analysisTemplates.successRate.failureLimit | default 3 }}
+    
+    # -- Success condition (result must be greater than threshold)
+    successCondition: {{ .Values.argoRollouts.analysisTemplates.successRate.successCondition | default "result > 0.95" | quote }}
+    
+    # -- Metric provider configuration (Prometheus)
+    provider:
+      prometheus:
+        # -- Prometheus server address
+        address: {{ .Values.argoRollouts.analysisTemplates.successRate.prometheusAddress | quote }}
+        
+        # -- PromQL query to calculate success rate
+        query: |
+          {{- tpl .Values.argoRollouts.analysisTemplates.successRate.query . | nindent 10 }}
+        
+        {{- if and .Values.argoRollouts.analysisTemplates.successRate.authentication .Values.argoRollouts.analysisTemplates.successRate.authentication.enabled }}
+        headers:
+          - key: Authorization
+            value: "Basic {{`{{ args.prometheusBasic }}`}}"
+        {{- end }}
+{{- end }}
+{{- end }}

--- a/templates/analysistemplate-kong.yaml.license
+++ b/templates/analysistemplate-kong.yaml.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 Deutsche Telekom AG
+
+SPDX-License-Identifier: Apache-2.0

--- a/templates/deployment-kong.yml
+++ b/templates/deployment-kong.yml
@@ -2,6 +2,7 @@
 {{- fail (printf "Cannot deploy stargate due to missing jwk secret. Use keyRotation.enabled or jumper.existingJwkSecretName with issuerService.existingJwkSecretName to provide jwk secrets") }}
 {{- end }}
 {{- include "keda.validate" . -}}
+{{- include "argoRollouts.validate" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -11,7 +12,7 @@ metadata:
   {{- include "kong.checksums" $ | nindent 4 }}
   labels: {{ include "kong.labels" $ | nindent 4 }}
 spec:
-{{- if not (or .Values.hpaAutoscaling.enabled .Values.kedaAutoscaling.enabled) }}
+{{- if not (or .Values.hpaAutoscaling.enabled .Values.kedaAutoscaling.enabled .Values.argoRollouts.enabled) }}
   replicas: {{ .Values.replicas | default 1 }}
 {{- end }}
 {{- if .Values.strategy.rollingUpdate }}

--- a/templates/rollout-kong.yaml
+++ b/templates/rollout-kong.yaml
@@ -1,0 +1,107 @@
+{{- if .Values.argoRollouts.enabled }}
+{{- include "argoRollouts.validate" . -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: {{ .Release.Name }}
+  annotations:
+  {{- include "kong.annotations" $ | nindent 4 }}
+  labels: {{ include "kong.labels" $ | nindent 4 }}
+spec:
+  # ============================================================================
+  # Replica Management
+  # ============================================================================
+  {{- if not .Values.kedaAutoscaling.enabled }}
+  replicas: {{ .Values.replicas | default 1 }}
+  {{- end }}
+  
+  # ============================================================================
+  # Workload Reference
+  # ============================================================================
+  # Reference to existing Deployment resource
+  # Argo Rollouts will manage this Deployment during progressive delivery
+  workloadRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}
+    scaleDown: onsuccess
+  
+  # ============================================================================
+  # Selector
+  # ============================================================================
+  selector:
+    matchLabels: {{ include "kong.selector" $ | nindent 6 }}
+  
+  # ============================================================================
+  # Rollout Strategy
+  # ============================================================================
+  strategy:
+{{- if eq .Values.argoRollouts.strategy.type "canary" }}
+    canary:
+      # ============================================================================
+      # Canary Configuration
+      # ============================================================================
+      {{- with .Values.argoRollouts.strategy.canary.additionalProperties }}
+      {{- toYaml . | nindent 6}}
+      {{- end }}
+
+      # ============================================================================
+      # Traffic Routing
+      # ============================================================================
+      # -- Name of the canary service (receives canary traffic)
+      canaryService: "{{ .Release.Name }}-proxy-canary"
+      # -- Name of the stable service (receives stable traffic)
+      stableService: "{{ .Release.Name }}-proxy"
+      trafficRouting:
+        nginx:
+          stableIngress: "{{ .Release.Name }}-proxy"
+          additionalIngressAnnotations:
+            canary-by-header: x-canary
+
+      # ============================================================================
+      # Canary Steps
+      # ============================================================================
+      {{- with .Values.argoRollouts.strategy.canary.steps }}
+      steps:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      # ============================================================================
+      # Background Analysis (Optional)
+      # ============================================================================
+      {{- if .Values.argoRollouts.strategy.canary.analysis }}
+      {{- if .Values.argoRollouts.strategy.canary.analysis.templates }}
+      analysis:
+        {{- with .Values.argoRollouts.strategy.canary.analysis.startingStep }}
+        startingStep: {{ . }}
+        {{- end }}
+        templates:
+        {{- range .Values.argoRollouts.strategy.canary.analysis.templates }}
+        - templateName: {{ $.Release.Name }}-{{ .templateName }}
+        {{- end }}
+        {{- if .Values.argoRollouts.strategy.canary.analysis.args }}
+        args:
+        {{- with .Values.argoRollouts.strategy.canary.analysis.args }}
+          {{- toYaml . }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
+      {{- end }}
+{{- else if eq .Values.argoRollouts.strategy.type "blueGreen" }}
+    blueGreen:
+      # Blue-Green strategy configuration
+      # This can be extended based on requirements
+      activeService: {{ .Release.Name }}-proxy
+      previewService: {{ .Release.Name }}-proxy-canary
+
+      {{- with .Values.argoRollouts.strategy.blueGreen }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+
+{{- end }}
+  
+  # ============================================================================
+  # Revision History
+  # ============================================================================
+  revisionHistoryLimit: 10
+{{- end }}

--- a/templates/rollout-kong.yaml.license
+++ b/templates/rollout-kong.yaml.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 Deutsche Telekom AG
+
+SPDX-License-Identifier: Apache-2.0

--- a/templates/service-proxy-canary.yml
+++ b/templates/service-proxy-canary.yml
@@ -1,0 +1,20 @@
+{{- if .Values.argoRollouts.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-proxy-canary
+  labels: {{ include "kong.labels" $ | nindent 4 }}
+spec:
+  selector: {{ include "kong.selector" $ | nindent 4 }}
+  ports:
+{{- if .Values.proxy.tls.enabled }}
+  - name: proxy-ssl
+    port: 8443
+    targetPort: 8443
+{{- else }}
+  - name: proxy
+    port: 8000
+    targetPort: 8000
+{{- end }}
+    protocol: TCP
+{{- end }}

--- a/templates/service-proxy-canary.yml.license
+++ b/templates/service-proxy-canary.yml.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 Deutsche Telekom AG
+
+SPDX-License-Identifier: Apache-2.0

--- a/values.yaml
+++ b/values.yaml
@@ -450,7 +450,7 @@ kedaAutoscaling:
       enabled: true
       
       # -- Victoria Metrics server address (REQUIRED if enabled)
-      # Example: "http://vmauth-raccoon.monitoring.svc.cluster.local:8427"
+      # Example: "http://prometheus.monitoring.svc.cluster.local:8427"
       # Can use template variables: "{{ .Values.global.vmauth.url }}"
       serverAddress: ""
       
@@ -962,3 +962,171 @@ pdb:
   minAvailable:
   # --  maxUnavailable pods in number or percent (defaults to 1 if unset and minAvailable also unset)
   maxUnavailable:
+
+# ============================================================================
+# Argo Rollouts Configuration
+# ============================================================================
+# Argo Rollouts provides advanced deployment capabilities with progressive 
+# delivery strategies like canary and blue-green deployments.
+#
+# Prerequisites:
+# - Argo Rollouts must be installed in the cluster
+# - For metric-based analysis, a metrics provider (Prometheus/Victoria Metrics) must be accessible
+#
+# Note: argoRollouts is mutually exclusive with standard Deployment.
+# When enabled, a Rollout resource replaces the Deployment using workloadRef.
+# ============================================================================
+
+argoRollouts:
+  # -- Enable Argo Rollouts progressive delivery (replaces standard Deployment)
+  enabled: false
+  
+  # ============================================================================
+  # Rollout Strategy Configuration
+  # ============================================================================
+  strategy:
+    # -- Deployment strategy type: "canary" or "blueGreen"
+    type: canary
+    
+    # -- Canary strategy configuration
+    canary:
+      additionalProperties:
+        # -- Maximum number of pods that can be unavailable during rollout (number or percentage)
+        maxUnavailable: "50%"
+
+        # -- Maximum number of extra pods that can be created during rollout (number or percentage)
+        maxSurge: "25%"
+        # -- Time to wait before scaling down the old ReplicaSet after successful rollout (in seconds)
+        scaleDownDelaySeconds: 60
+
+      # ============================================================================
+      # Canary Steps Configuration
+      # ============================================================================
+      # Define the progression of traffic shift during canary deployment
+      # Each step can set weight, pause duration, or trigger analysis
+      
+      steps:
+        # Step 1: Route 10% of traffic to canary
+        - setWeight: 10
+        # Step 2: Pause for 2 minutes
+        - pause:
+            duration: 2m
+        # Final step: Full promotion (100% to canary, 0% to stable)
+
+      # ============================================================================
+      # Analysis Configuration
+      # ============================================================================
+      # Optional background analysis that runs continuously during canary
+      
+      analysis:
+        # -- AnalysisTemplate references for background analysis
+        templates:
+          - templateName: success-rate-analysis
+        # -- Arguments to pass to the analysis template
+        args: []
+        # -- Canary step at which to start the analysis (1-based index)
+        startingStep:
+
+    # -- blueGreen strategy configuration (except activeService and previewService - these are handled by template)
+    blueGreen:
+      autoPromotionEnabled: false
+
+  # ============================================================================
+  # Analysis Templates Configuration
+  # ============================================================================
+  # Define metrics and success criteria for automated rollout validation
+  
+  analysisTemplates:
+    # -- Enable creation of AnalysisTemplates
+    enabled: true
+    
+    # ============================================================================
+    # Error Rate Analysis Template
+    # ============================================================================
+    # Validates that error rate stays below acceptable threshold
+    
+    errorRate:
+      # -- Enable error rate analysis
+      enabled: true
+      # -- Analysis interval (how often to check)
+      interval: 30s
+      # -- Number of measurements to take
+      count: 0
+      # -- Number of failed measurements that trigger rollback
+      failureLimit: 2
+      # -- Success criteria (PromQL query must return < threshold)
+      successCondition: "all(result, # < 0.05)"
+      # -- Error rate threshold (5% = 0.05)
+      # PromQL query to calculate error rate over last 5 minutes
+      query: |
+        sum(irate(
+        nginx_ingress_controller_request_duration_seconds_count{exported_namespace="{{`{{ args.namespace }}`}}",exported_service="{{`{{ args.service-name }}`}}",ingress="{{`{{ args.service-name }}`}}",canary!="",status!~"5.."}[1m]
+        )) /
+        sum(irate(
+        nginx_ingress_controller_request_duration_seconds_count{exported_namespace="{{`{{ args.namespace }}`}}",exported_service="{{`{{ args.service-name }}`}}",ingress="{{`{{ args.service-name }}`}}",canary!=""}[1m]
+        ))
+      # -- Prometheus server address (must be accessible)
+      # Example: "http://prometheus.monitoring.svc.cluster.local:8427"
+      prometheusAddress: ""
+      
+      # -- Prometheus authentication using Basic Auth
+      # Credentials are read from a Kubernetes secret in the same namespace
+      authentication:
+        # -- Enable authentication for Prometheus queries
+        enabled: true
+        
+        # -- Secret name containing Prometheus credentials
+        # This secret must exist in the same namespace as the Rollout
+        # Example secret creation:
+        #   apiVersion: v1
+        #   kind: Secret
+        #   metadata:
+        #     name: victoria-metrics-secret
+        #   type: Opaque
+        #   stringData:
+        #     username: "my-username"
+        #     password: "my-password"
+        secretName: "victoria-metrics-secret"
+        
+        # -- Secret key containing base64 encoded user:password combination to be used as Basic Auth header
+        basicKey: "basic-auth"
+
+    # ============================================================================
+    # Success Rate Analysis Template
+    # ============================================================================
+    # Validates that success rate stays above acceptable threshold
+    
+    successRate:
+      # -- Enable success rate analysis
+      enabled: true
+      # -- Analysis interval
+      interval: 30s
+      # -- Number of measurements to take
+      count: 0
+      # -- Number of failed measurements that trigger rollback
+      failureLimit: 3
+      # -- Success criteria (PromQL query must return > threshold)
+      successCondition: "all(result, # >= 0.95)"
+      # -- Success rate threshold (95% = 0.95)
+      # PromQL query to calculate success rate over last 1 minute
+      query: |
+        sum(irate(
+          nginx_ingress_controller_request_duration_seconds_count{exported_namespace="{{`{{ args.namespace }}`}}",exported_service="{{`{{ args.service-name }}`}}",ingress="{{`{{ args.service-name }}`}}",canary!="",status!~"(4|5).*"}[1m]
+        )) /
+        sum(irate(
+          nginx_ingress_controller_request_duration_seconds_count{exported_namespace="{{`{{ args.namespace }}`}}",exported_service="{{`{{ args.service-name }}`}}",ingress="{{`{{ args.service-name }}`}}",canary!=""}[1m]
+        ))
+      # -- Prometheus server address
+      prometheusAddress: ""
+      
+      # -- Prometheus authentication using Basic Auth
+      # Credentials are read from a Kubernetes secret in the same namespace
+      authentication:
+        # -- Enable authentication for Prometheus queries
+        enabled: true
+        
+        # -- Secret name containing Prometheus credentials
+        secretName: "victoria-metrics-secret"
+        
+        # -- Secret key containing base64 encoded user:password combination to be used as Basic Auth header
+        basicKey: "basic-auth"


### PR DESCRIPTION
- Added Argo Rollouts support with canary and blue-green deployment strategies
- Created rollout templates including rollout-kong.yaml, analysistemplate-kong.yaml, and canary service
- Implemented automated analysis with error rate and success rate validation via Prometheus/Victoria Metrics
- Added comprehensive documentation in docs/ARGO_ROLLOUTS_FEATURE.md
- Extended values.yaml with 170+ lines of Argo Rollouts configuration options
- Updated README with usage examples and configuration details