### PR TITLE
fix: enable canary dynamicStableScale per default

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,13 +672,13 @@ This is a short overlook about important parameters in the `values.yaml`.
 | argoRollouts.analysisTemplates.successRate.successCondition | string | `"all(result, # >= 0.95)"` | Success criteria (PromQL query must return > threshold) |
 | argoRollouts.enabled | bool | `false` | Enable Argo Rollouts progressive delivery (replaces standard Deployment) |
 | argoRollouts.strategy.blueGreen | object | `{"autoPromotionEnabled":false}` | blueGreen strategy configuration (except activeService and previewService - these are handled by template) |
+| argoRollouts.strategy.canary.additionalProperties.dynamicStableScale | bool | `true` | Enable dynamic stable scale (mutual exclusive to scaleDownDelaySeconds ) |
 | argoRollouts.strategy.canary.additionalProperties.maxSurge | string | `"25%"` | Maximum number of extra pods that can be created during rollout (number or percentage) |
 | argoRollouts.strategy.canary.additionalProperties.maxUnavailable | string | `"50%"` | Maximum number of pods that can be unavailable during rollout (number or percentage) |
-| argoRollouts.strategy.canary.additionalProperties.scaleDownDelaySeconds | int | `60` | Time to wait before scaling down the old ReplicaSet after successful rollout (in seconds) |
 | argoRollouts.strategy.canary.analysis.args | list | `[]` | Arguments to pass to the analysis template |
 | argoRollouts.strategy.canary.analysis.startingStep | string | `nil` | Canary step at which to start the analysis (1-based index) |
 | argoRollouts.strategy.canary.analysis.templates | list | `[{"templateName":"success-rate-analysis"}]` | AnalysisTemplate references for background analysis |
-| argoRollouts.strategy.canary.steps | list | `[{"setWeight":10},{"pause":{"duration":"5m"}}]` | Canary step definition with a weight of 10% and a pause of 5 minutes |
+| argoRollouts.strategy.canary.steps | list | `[{"setWeight":10},{"pause":{"duration":"1m"}},{"setWeight":20},{"pause":{"duration":"1m"}},{"setWeight":40},{"pause":{"duration":"1m"}},{"setWeight":60},{"pause":{"duration":"1m"}},{"setWeight":80},{"pause":{"duration":"1m"}}]` | Canary step definition with a weight of 10% and a pause of 5 minutes |
 | argoRollouts.strategy.type | string | `"canary"` | Deployment strategy type: "canary" or "blueGreen" |
 | argoRollouts.workloadRef.scaleDown | string | `"progressively"` | scaleDown strategy for Argo Rollouts deployment workloadRef |
 | circuitbreaker.enabled | bool | `false` | enable deployment of circuitbreaker component |

--- a/templates/rollout-kong.yaml
+++ b/templates/rollout-kong.yaml
@@ -26,6 +26,8 @@ spec:
     name: {{ .Release.Name }}
     scaleDown: {{ .Values.argoRollouts.workloadRef.scaleDown | default "progressively" }}
   
+  progressDeadlineSeconds: {{ .Values.argoRollouts.progressDeadlineSeconds | default 1200 }}
+
   # ============================================================================
   # Selector
   # ============================================================================

--- a/values.yaml
+++ b/values.yaml
@@ -1000,8 +1000,9 @@ argoRollouts:
 
         # -- Maximum number of extra pods that can be created during rollout (number or percentage)
         maxSurge: "25%"
-        # -- Time to wait before scaling down the old ReplicaSet after successful rollout (in seconds)
-        scaleDownDelaySeconds: 60
+
+        # -- Enable dynamic stable scale (mutual exclusive to scaleDownDelaySeconds )
+        dynamicStableScale: true
 
       # ============================================================================
       # Canary Steps Configuration
@@ -1011,12 +1012,21 @@ argoRollouts:
 
       # -- Canary step definition with a weight of 10% and a pause of 5 minutes
       steps:
-        # Step 1: Route 10% of traffic to canary
         - setWeight: 10
-        # Step 2: Pause for 5 minutes
         - pause:
-            duration: 5m
-        # Final step: Full promotion (100% to canary, 0% to stable)
+            duration: 1m
+        - setWeight: 20
+        - pause:
+            duration: 1m
+        - setWeight: 40
+        - pause:
+            duration: 1m
+        - setWeight: 60
+        - pause:
+            duration: 1m            
+        - setWeight: 80
+        - pause:
+            duration: 1m
 
       # ============================================================================
       # Analysis Configuration


### PR DESCRIPTION
- default to more ressource saving canary rollouts with scaling down old stable pods before fully promoting the canary -deployment
- additionally default context deadline to 10 minutes and make it configurable