### PR TITLE
fix: bump default gateway-kong-image to 1.2.1

### DIFF
--- a/templates/_kong.tpl
+++ b/templates/_kong.tpl
@@ -14,7 +14,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}-kong
 
 {{- define "kong.image" -}}
 {{- $imageName := "kong" -}}
-{{- $imageTag := "1.1.0" -}}
+{{- $imageTag := "1.2.1" -}}
 {{- $imageRepository := "mtr.devops.telekom.de" -}}
 {{- $imageOrganization := "tardis-internal/gateway" -}}
 {{- if .Values.image -}}


### PR DESCRIPTION
The new image contains a bump to version 1.6.0-1 of the jwt-kycloak plugin.  
See the release notes [here](https://github.com/telekom/kong-plugin-jwt-keycloak/releases/tag/1.6.0-1).