### PR TITLE
fix(ci): add extra_plugins for semantic release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,5 +62,8 @@ jobs:
           branches: |
             ['main']
           tag_format: '${version}'
+          extra_plugins: |
+            @semantic-release/exec
+            @semantic-release/git
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes failing release workflow ([example](https://github.com/telekom/gateway-kong-charts/actions/runs/19820052331/job/56780116030)).