### PR TITLE
fix: revert changes from patch release 9.0.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-      actions: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: v2
-name: gateway
+name: stargate
 version: 9.0.1
 description: Kong API gateway provided by o28m
 maintainers:


### PR DESCRIPTION
The new Chart name "gateway" introduced in 9.0.1 will break upgrades as it will change existing selector labels.
The change has therefore been reverted for now.