### PR TITLE
feat: add NetworkPolicy support for gateway pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,6 +782,7 @@ The following table provides a comprehensive list of all configurable parameters
 | logFormat | string | `"json"` | Nginx log format: debug, default, json, or plain |
 | memCacheSize | string | `"128m"` | Kong memory cache size for database entities |
 | migrations | string | `"none"` | Migration mode for database initialization or upgrades |
+| networkPolicy.enabled | bool | `false` | Enable NetworkPolicy for the gateway pods |
 | nginxHttpLuaSharedDict | string | `"prometheus_metrics 15m"` | Nginx HTTP Lua shared dictionary for storing metrics |
 | nginxWorkerProcesses | int | `4` | Number of nginx worker processes |
 | pdb.create | bool | `false` | Enable PodDisruptionBudget creation |

--- a/templates/networkpolicy.yaml
+++ b/templates/networkpolicy.yaml
@@ -1,0 +1,73 @@
+{{/*
+SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
+
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}
+  labels: {{ include "app.labels.standard" $ | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels: {{ include "app.labels.selectorLabels" $ | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    {{- if .Values.networkPolicy.ingress }}
+    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
+    {{- else }}
+    # Default: Allow proxy traffic
+    - ports:
+      {{- if .Values.proxy.tls.enabled }}
+        - port: 8443
+          protocol: TCP
+      {{- else }}
+        - port: 8000
+          protocol: TCP
+      {{- end }}
+    {{- if .Values.adminApi.enabled }}
+    # Allow admin API traffic
+    - ports:
+      {{- if .Values.adminApi.tls.enabled }}
+        - port: 8444
+          protocol: TCP
+      {{- else }}
+        - port: 8001
+          protocol: TCP
+      {{- end }}
+    {{- end }}
+    {{- if .Values.plugins.prometheus.enabled }}
+    # Allow metrics scraping
+    - ports:
+        - port: {{ .Values.plugins.prometheus.port | default 9542 }}
+          protocol: TCP
+    {{- end }}
+    # Allow status endpoint (health checks)
+    - ports:
+        - port: 8100
+          protocol: TCP
+    {{- if .Values.jumper.enabled }}
+    # Allow jumper traffic
+    - ports:
+        - port: {{ .Values.jumper.port }}
+          protocol: TCP
+    {{- end }}
+    {{- if .Values.issuerService.enabled }}
+    # Allow issuer service traffic
+    - ports:
+        - port: {{ .Values.issuerService.port | default 8081 }}
+          protocol: TCP
+    {{- end }}
+    {{- end }}
+  egress:
+    {{- if .Values.networkPolicy.egress }}
+    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
+    {{- else }}
+    # Default: Allow all egress
+    - {}
+    {{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -1307,3 +1307,32 @@ argoRollouts:
         
         # -- Secret key for base64 encoded user:password Basic Auth header
         basicKey: "basic-auth"
+
+# ============================================================================
+# Network Policy Configuration
+# ============================================================================
+# NetworkPolicy controls traffic flow to and from the gateway pods.
+# When enabled, only explicitly allowed traffic is permitted.
+# ============================================================================
+
+networkPolicy:
+  # -- Enable NetworkPolicy for the gateway pods
+  enabled: false
+  
+  # -- Custom ingress rules (if not set, default rules based on enabled components are used)
+  # ingress:
+  #   - from:
+  #       - namespaceSelector:
+  #           matchLabels:
+  #             kubernetes.io/metadata.name: ingress-nginx
+  #     ports:
+  #       - port: 8000
+  #         protocol: TCP
+  
+  # -- Custom egress rules (if not set, all egress is allowed)
+  # egress:
+  #   - to:
+  #       - namespaceSelector: {}
+  #     ports:
+  #       - port: 443
+  #         protocol: TCP


### PR DESCRIPTION
- added networkpolicy option disabled by default
- when enabled ingress defaults to allow traffic to rendered ports
- when enabled egress defaults to allow all
- ingress and egress traffic can be customized completely