### PR TITLE
fix: introduce option for setting MALLOC_ARENA_MAX

### DIFF
--- a/templates/_kong.tpl
+++ b/templates/_kong.tpl
@@ -368,6 +368,10 @@ false
   value: 'false'
 - name: KONG_NGINX_HTTP_CLIENT_BODY_BUFFER_SIZE
   value: '{{ .Values.httpClientBodyBufferSize | default "4m" }}'
+{{- if .Values.mallocArenaMax }}
+- name: MALLOC_ARENA_MAX
+  value: '{{ .Values.mallocArenaMax }}'
+{{- end }}
 {{- if .Values.trustedIps }}
 - name: KONG_TRUSTED_IPS
   value: '{{ .Values.trustedIps }}'

--- a/values.yaml
+++ b/values.yaml
@@ -260,6 +260,8 @@ dbUpdateFrequency: 10
 dbUpdatePropagation: 0
 # -- HTTP client body buffer size (optional override)
 #httpClientBodyBufferSize: 4m
+# -- glibc MALLOC_ARENA_MAX setting to reduce memory fragmentation (optional override, default: 8 * CPU cores)
+#mallocArenaMax: 2
 # -- Trusted IPs for real IP detection (optional override)
 #trustedIps: 100.70.0.0/16
 # -- Header to use for real IP detection (optional override)


### PR DESCRIPTION
Add configurable mallocArenaMax value to reduce glibc memory fragmentation in Kong containers. When not set, glibc defaults to 8 * CPU cores, which can lead to heap fragmentation and memory not being returned to the OS after load spikes.

Setting this to a low value (e.g., 2) might reduce fragmentation area, though this does not affect Kong/Lua allocations through LuaJIT's allocator, which doesn't rely on glibc.