### PR TITLE
feat(keda): add external scaler trigger support

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ For configuration options, see the `hpaAutoscaling.*` values in the [Parameters]
 - **Anti-flapping protection**: Sophisticated cooldown periods and stabilization windows
 - **Custom metrics**: Scale based on request rate, error rate, or any Prometheus/Victoria Metrics query
 - **Schedule-based scaling**: Pre-scale for known traffic patterns (business hours, weekends, etc.)
+- **External scalers**: Integrate any gRPC-based [KEDA external scaler](https://keda.sh/docs/2.19/scalers/external/) for custom scaling logic
 
 **Prerequisites:**
 - KEDA must be installed in the cluster: `helm install keda kedacore/keda --namespace keda --create-namespace`
@@ -354,11 +355,38 @@ kedaAutoscaling:
       enabled: false
 ```
 
+**External Scaler** (e.g. for proactive time-window based scaling):
+
+Each entry in `external.scalers` produces a separate KEDA external trigger.
+The `metadata` map is forwarded 1:1 to the scaler service via gRPC.
+Only `scalerAddress` is required by the chart; all other keys are scaler-specific.
+This is typically provided via Argo CD `helmValues` or a separate values file.
+
+```yaml
+kedaAutoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 200
+  triggers:
+    external:
+      enabled: true
+      scalers:
+        - metadata:
+            scalerAddress: "my-external-scaler.keda.svc.cluster.local:6000"
+            campaignName: "fifa-worldcup-2026"
+            targetReplicas: "100"
+        - metadata:
+            scalerAddress: "my-external-scaler.keda.svc.cluster.local:6000"
+            campaignName: "black-friday-2026"
+            targetReplicas: "50"
+```
+
 For configuration options, see the `kedaAutoscaling.*` values in the [Parameters](#parameters) section below.
 
 **References:**
 - [KEDA Documentation](https://keda.sh/docs/)
 - [KEDA Scalers](https://keda.sh/docs/scalers/)
+- [KEDA External Scalers](https://keda.sh/docs/2.19/scalers/external/)
 - [Victoria Metrics PromQL](https://docs.victoriametrics.com/MetricsQL.html)
 
 ### Argo Rollouts (Progressive Delivery)
@@ -839,6 +867,8 @@ The following table provides a comprehensive list of all configurable parameters
 | kedaAutoscaling.triggers.cron.enabled | bool | `false` | Enable cron-based (schedule) scaling |
 | kedaAutoscaling.triggers.cron.schedules | list | `[]` | Cron schedule definitions (time windows with desired replica counts) Each schedule defines start/end times and replica count Multiple schedules can overlap (highest desiredReplicas wins) |
 | kedaAutoscaling.triggers.cron.timezone | string | `"Europe/Berlin"` | Timezone for cron schedules Use IANA timezone database names for automatic DST handling Europe/Berlin automatically handles CET (UTC+1) and CEST (UTC+2) transitions Format: IANA timezone (e.g., "Europe/Berlin", "America/New_York", "Asia/Tokyo") See: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones |
+| kedaAutoscaling.triggers.external.enabled | bool | `false` | Enable external scaler triggers |
+| kedaAutoscaling.triggers.external.scalers | list | `[]` | List of external scaler trigger definitions Each entry produces a separate KEDA external trigger in the ScaledObject. The metadata map of each entry is forwarded 1:1 to the scaler via gRPC. scalerAddress is REQUIRED in every entry; all other keys depend on the external scaler implementation. |
 | kedaAutoscaling.triggers.memory.containers | object | `{"issuerService":{"enabled":true,"threshold":85},"jumper":{"enabled":true,"threshold":85},"kong":{"enabled":true,"threshold":95}}` | Per-container memory thresholds (any container exceeding threshold triggers scaling) |
 | kedaAutoscaling.triggers.memory.containers.issuerService | object | `{"enabled":true,"threshold":85}` | Issuer Service container memory scaling configuration |
 | kedaAutoscaling.triggers.memory.containers.issuerService.enabled | bool | `true` | Enable memory monitoring for Issuer Service container |

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -325,6 +325,7 @@ For configuration options, see the `hpaAutoscaling.*` values in the [Parameters]
 - **Anti-flapping protection**: Sophisticated cooldown periods and stabilization windows
 - **Custom metrics**: Scale based on request rate, error rate, or any Prometheus/Victoria Metrics query
 - **Schedule-based scaling**: Pre-scale for known traffic patterns (business hours, weekends, etc.)
+- **External scalers**: Integrate any gRPC-based [KEDA external scaler](https://keda.sh/docs/2.19/scalers/external/) for custom scaling logic
 
 **Prerequisites:**
 - KEDA must be installed in the cluster: `helm install keda kedacore/keda --namespace keda --create-namespace`
@@ -354,11 +355,38 @@ kedaAutoscaling:
       enabled: false
 ```
 
+**External Scaler** (e.g. for proactive time-window based scaling):
+
+Each entry in `external.scalers` produces a separate KEDA external trigger.
+The `metadata` map is forwarded 1:1 to the scaler service via gRPC.
+Only `scalerAddress` is required by the chart; all other keys are scaler-specific.
+This is typically provided via Argo CD `helmValues` or a separate values file.
+
+```yaml
+kedaAutoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 200
+  triggers:
+    external:
+      enabled: true
+      scalers:
+        - metadata:
+            scalerAddress: "my-external-scaler.keda.svc.cluster.local:6000"
+            campaignName: "fifa-worldcup-2026"
+            targetReplicas: "100"
+        - metadata:
+            scalerAddress: "my-external-scaler.keda.svc.cluster.local:6000"
+            campaignName: "black-friday-2026"
+            targetReplicas: "50"
+```
+
 For configuration options, see the `kedaAutoscaling.*` values in the [Parameters](#parameters) section below.
 
 **References:**
 - [KEDA Documentation](https://keda.sh/docs/)
 - [KEDA Scalers](https://keda.sh/docs/scalers/)
+- [KEDA External Scalers](https://keda.sh/docs/2.19/scalers/external/)
 - [Victoria Metrics PromQL](https://docs.victoriametrics.com/MetricsQL.html)
 
 ### Argo Rollouts (Progressive Delivery)

--- a/templates/keda/_validation.tpl
+++ b/templates/keda/_validation.tpl
@@ -1,11 +1,5 @@
 {{/*
-SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
-
-SPDX-License-Identifier: Apache-2.0
-*/}}
-
-{{/*
-SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
+SPDX-FileCopyrightText: 2025-2026 Deutsche Telekom AG
 
 SPDX-License-Identifier: Apache-2.0
 */}}
@@ -35,12 +29,24 @@ KEDA Autoscaling Validation
 {{- end -}}
 {{- end -}}
 
-{{- /* Validation 4: At least one trigger must be enabled */ -}}
+{{- /* Validation 4: External scaler requires at least one trigger with scalerAddress */ -}}
+{{- if .Values.kedaAutoscaling.triggers.external.enabled -}}
+{{- if not .Values.kedaAutoscaling.triggers.external.scalers -}}
+{{- fail "ERROR: kedaAutoscaling.triggers.external.scalers must contain at least one entry when external trigger is enabled" -}}
+{{- end -}}
+{{- range $i, $t := .Values.kedaAutoscaling.triggers.external.scalers -}}
+{{- if not $t.metadata.scalerAddress -}}
+{{- fail (printf "ERROR: kedaAutoscaling.triggers.external.scalers[%d].metadata.scalerAddress is required" $i) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- /* Validation 5: At least one trigger must be enabled */ -}}
 {{- $hasCpuTrigger := and .Values.kedaAutoscaling.triggers.cpu.enabled (or .Values.kedaAutoscaling.triggers.cpu.containers.kong.enabled (and .Values.jumper.enabled .Values.kedaAutoscaling.triggers.cpu.containers.jumper.enabled) (and .Values.issuerService.enabled .Values.kedaAutoscaling.triggers.cpu.containers.issuerService.enabled)) -}}
 {{- $hasMemoryTrigger := and .Values.kedaAutoscaling.triggers.memory.enabled (or .Values.kedaAutoscaling.triggers.memory.containers.kong.enabled (and .Values.jumper.enabled .Values.kedaAutoscaling.triggers.memory.containers.jumper.enabled) (and .Values.issuerService.enabled .Values.kedaAutoscaling.triggers.memory.containers.issuerService.enabled)) -}}
-{{- $hasEnabledTrigger := or $hasCpuTrigger $hasMemoryTrigger .Values.kedaAutoscaling.triggers.prometheus.enabled .Values.kedaAutoscaling.triggers.cron.enabled -}}
+{{- $hasEnabledTrigger := or $hasCpuTrigger $hasMemoryTrigger .Values.kedaAutoscaling.triggers.prometheus.enabled .Values.kedaAutoscaling.triggers.cron.enabled .Values.kedaAutoscaling.triggers.external.enabled -}}
 {{- if not $hasEnabledTrigger -}}
-{{- fail "ERROR: At least one kedaAutoscaling trigger must be enabled with at least one container configured (cpu, memory, prometheus, or cron)" -}}
+{{- fail "ERROR: At least one kedaAutoscaling trigger must be enabled with at least one container configured (cpu, memory, prometheus, cron, or external)" -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/templates/keda/scaledobject.yaml
+++ b/templates/keda/scaledobject.yaml
@@ -134,4 +134,13 @@ spec:
     {{- end }}
   {{- end }}
   {{- end }}
+  
+  # External Scalers
+  {{- if .Values.kedaAutoscaling.triggers.external.enabled }}
+  {{- range .Values.kedaAutoscaling.triggers.external.scalers }}
+  - type: external
+    metadata:
+      {{- toYaml .metadata | nindent 6 }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -48,10 +48,10 @@ global:
     length: 12
     # -- Password must match these regex patterns
     mustMatch:
-    - '[a-z]'
-    - '[A-Z]'
-    - '[0-9]'
-    - '[^a-zA-Z0-9]'
+      - "[a-z]"
+      - "[A-Z]"
+      - "[0-9]"
+      - "[^a-zA-Z0-9]"
 
   database:
     # -- Database location: 'local' (deploy with chart) or 'external' (provided externally)
@@ -108,7 +108,6 @@ imagePullPolicy: IfNotPresent
 # -- Migration mode for database initialization or upgrades
 migrations: none
 
-
 # Kong Admin API configuration
 adminApi:
   # -- Create Service for Kong Admin API
@@ -143,7 +142,6 @@ adminApi:
       #  hosts:
       #    - hostNameMatchingCertInSecret
 
-
 # Kong Proxy configuration
 proxy:
   tls:
@@ -174,13 +172,13 @@ proxy:
 
 # -- Post-deployment configuration script (curl commands for Admin API)
 #configuration: |
-  #Place your curl commands for configuring the Admin API here
+#Place your curl commands for configuring the Admin API here
 
 # SSL/TLS configuration
 # -- Enable SSL certificate verification for upstream traffic
 sslVerify: false
 # -- SSL certificate verification depth
-sslVerifyDepth: '1'
+sslVerifyDepth: "1"
 
 # -- CA certificates bundle in PEM format for SSL verification
 #trustedCaCertificates: |
@@ -227,7 +225,7 @@ containerSecurityContext:
     type: RuntimeDefault
   capabilities:
     drop:
-    - ALL
+      - ALL
 
 # -- Topology key for pod anti-affinity (spread pods across zones for high availability)
 topologyKey: kubernetes.io/hostname
@@ -246,7 +244,7 @@ jobs:
       type: RuntimeDefault
     capabilities:
       drop:
-      - ALL
+        - ALL
 
 # -- Kong memory cache size for database entities
 memCacheSize: 128m
@@ -314,52 +312,52 @@ hpaAutoscaling:
 kedaAutoscaling:
   # -- Enable KEDA-based autoscaling (disables standard HPA if enabled)
   enabled: false
-  
+
   # ============================================================================
   # Replica Boundaries
   # ============================================================================
-  
+
   # -- Minimum number of replicas (must be >= 1)
   minReplicas: 2
-  
+
   # -- Maximum number of replicas (must be >= minReplicas)
   maxReplicas: 10
-  
+
   # ============================================================================
   # Timing Configuration (Anti-Flapping)
   # ============================================================================
-  
+
   # -- Polling interval in seconds (how often KEDA checks metrics)
   # Lower values = more responsive but more API calls
   # Recommended: 30-60 seconds for balanced behavior
   pollingInterval: 30
-  
+
   # -- Cooldown period in seconds (minimum time between scale-down actions)
   # Prevents rapid scale-down oscillations
   # Recommended: 300 seconds (5 minutes) for stable workloads
   cooldownPeriod: 300
-  
+
   # ============================================================================
   # Fallback Configuration
   # ============================================================================
   # Defines behavior when all scaling triggers fail (e.g., metrics unavailable)
-  
+
   fallback:
     # -- Enable fallback to a fixed replica count when all triggers fail
     enabled: false
-    
+
     # -- Number of replicas to maintain when all triggers fail (e.g. maxReplicas)
     replicas: 10
-  
+
   # ============================================================================
   # Advanced HPA Behavior Configuration
   # ============================================================================
   # Fine-tune scaling behavior using Kubernetes HPA v2 behavior policies
-  
+
   advanced:
     # -- Restore to original replica count when ScaledObject is deleted
     restoreToOriginalReplicaCount: false
-    
+
     # -- HPA behavior configuration (scale-up/scale-down policies)
     horizontalPodAutoscalerConfig:
       # -- Scaling behavior policies
@@ -368,53 +366,52 @@ kedaAutoscaling:
         scaleDown:
           # -- Stabilization window for scale-down in seconds (KEDA waits before scaling down)
           stabilizationWindowSeconds: 300
-          
+
           # -- Scale-down policies (multiple policies can be defined)
           policies:
-          - type: Percent
-            value: 10        # Max 10% reduction per period
-            periodSeconds: 60
-          
+            - type: Percent
+              value: 10 # Max 10% reduction per period
+              periodSeconds: 60
+
           # -- Policy selection (Min = most conservative, Max = most aggressive)
           selectPolicy: Min
-        
+
         # -- Scale-up behavior (aggressive for availability)
         scaleUp:
           # -- Stabilization window for scale-up in seconds (0 = immediate scale-up)
           stabilizationWindowSeconds: 0
-          
+
           # -- Scale-up policies
           policies:
-          - type: Percent
-            value: 100       # Max 100% increase per period
-            periodSeconds: 60
-          - type: Pods
-            value: 4         # Or max 4 pods per period
-            periodSeconds: 60
-          
+            - type: Percent
+              value: 100 # Max 100% increase per period
+              periodSeconds: 60
+            - type: Pods
+              value: 4 # Or max 4 pods per period
+              periodSeconds: 60
+
           # -- Policy selection (Max = use most aggressive policy)
           selectPolicy: Max
-  
+
   # ============================================================================
   # Scaling Triggers
   # ============================================================================
   # Multiple triggers can be enabled simultaneously (OR logic)
   # If ANY trigger suggests scale-up → scale up
   # If ALL triggers suggest scale-down → scale down (after cooldown)
-  
+
   triggers:
-    
     # ==========================================================================
     # CPU Resource Scalers (Per-Container)
     # ==========================================================================
     # Scales based on CPU utilization percentage for individual containers
     # Requires: Kubernetes metrics server
     # Multiple containers can be monitored independently
-    
+
     cpu:
       # -- Enable CPU-based scaling for any container
       enabled: true
-      
+
       # -- Per-container CPU thresholds (any container exceeding threshold triggers scaling)
       containers:
         # -- Kong container CPU scaling configuration
@@ -423,32 +420,32 @@ kedaAutoscaling:
           enabled: true
           # -- CPU utilization threshold percentage (0-100, recommended: 60-80% for headroom)
           threshold: 70
-        
+
         # -- Jumper container CPU scaling configuration
         jumper:
           # -- Enable CPU monitoring for Jumper container
           enabled: true
           # -- CPU utilization threshold percentage (0-100)
           threshold: 70
-        
+
         # -- Issuer Service container CPU scaling configuration
         issuerService:
           # -- Enable CPU monitoring for Issuer Service container
           enabled: true
           # -- CPU utilization threshold percentage (0-100)
           threshold: 70
-    
+
     # ==========================================================================
     # Memory Resource Scalers (Per-Container)
     # ==========================================================================
     # Scales based on memory utilization percentage for individual containers
     # Requires: Kubernetes metrics server
     # Multiple containers can be monitored independently
-    
+
     memory:
       # -- Enable memory-based scaling for any container
       enabled: true
-      
+
       # -- Per-container memory thresholds (any container exceeding threshold triggers scaling)
       containers:
         # -- Kong container memory scaling configuration
@@ -457,39 +454,39 @@ kedaAutoscaling:
           enabled: true
           # -- Memory utilization threshold percentage (0-100, recommended: 80-90%)
           threshold: 95
-        
+
         # -- Jumper container memory scaling configuration
         jumper:
           # -- Enable memory monitoring for Jumper container
           enabled: true
           # -- Memory utilization threshold percentage (0-100)
           threshold: 85
-        
+
         # -- Issuer Service container memory scaling configuration
         issuerService:
           # -- Enable memory monitoring for Issuer Service container
           enabled: true
           # -- Memory utilization threshold percentage (0-100)
           threshold: 85
-    
+
     # ==========================================================================
     # Prometheus/Victoria Metrics Scaler
     # ==========================================================================
     # Scales based on custom metrics from Victoria Metrics
     # Requires: Victoria Metrics accessible, authentication configured
-    
+
     prometheus:
       # -- Enable Prometheus/Victoria Metrics based scaling
       enabled: true
-      
+
       # -- Victoria Metrics server address (REQUIRED if enabled)
       # Example: "http://prometheus.monitoring.svc.cluster.local:8427"
       # Can use template variables: "{{ .Values.global.vmauth.url }}"
       serverAddress: ""
-      
+
       # -- Metric name (used for identification in KEDA)
       metricName: "kong_request_rate"
-      
+
       # -- PromQL query to execute
       # Must return a single numeric value
       # Can use Helm template variables (e.g., {{ .Values.global.zone }})
@@ -497,21 +494,21 @@ kedaAutoscaling:
       #   - Request rate: sum(rate(kong_http_requests_total{zone="zone1"}[1m]))
       #   - Error rate: sum(rate(kong_http_requests_total{status=~"5.."}[1m]))
       query: 'sum(rate(kong_http_requests_total{ei_telekom_de_zone="{{ .Values.global.zone }}",ei_telekom_de_environment="{{ .Values.global.environment }}",app_kubernetes_io_instance="{{ .Release.Name }}-kong"}[1m]))'
-      
+
       # -- Threshold value for the metric
       # Scales up when query result exceeds this value
       # For request rate: total requests/second across all pods
       threshold: "100"
-      
+
       # -- Activation threshold (optional)
       # Minimum metric value to activate this scaler
       # Prevents scaling from 0 on minimal load
       activationThreshold: ""
-      
+
       # -- Authentication mode for Victoria Metrics
       # Options: "basic", "bearer", "tls"
       authModes: "basic"
-      
+
       # -- KEDA authentication configuration for Victoria Metrics access
       # Reference to existing TriggerAuthentication or ClusterTriggerAuthentication resource
       authentication:
@@ -519,7 +516,7 @@ kedaAutoscaling:
         # Use "TriggerAuthentication" for namespace-scoped environments
         # Use "ClusterTriggerAuthentication" for cluster-wide shared credentials
         kind: "ClusterTriggerAuthentication"
-        
+
         # -- Name of the TriggerAuthentication or ClusterTriggerAuthentication resource
         # This resource must be created separately and contain Victoria Metrics credentials
         # Example ClusterTriggerAuthentication:
@@ -551,24 +548,24 @@ kedaAutoscaling:
         #       name: victoria-metrics-secret
         #       key: password
         name: "eni-keda-vmselect-creds"
-    
+
     # ==========================================================================
     # Cron-Based Scalers
     # ==========================================================================
     # Scales based on time schedules (predictable traffic patterns)
     # Multiple schedules can be defined for different time windows
-    
+
     cron:
       # -- Enable cron-based (schedule) scaling
       enabled: false
-      
+
       # -- Timezone for cron schedules
       # Use IANA timezone database names for automatic DST handling
       # Europe/Berlin automatically handles CET (UTC+1) and CEST (UTC+2) transitions
       # Format: IANA timezone (e.g., "Europe/Berlin", "America/New_York", "Asia/Tokyo")
       # See: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
       timezone: "Europe/Berlin"
-      
+
       # -- Cron schedule definitions (time windows with desired replica counts)
       # Each schedule defines start/end times and replica count
       # Multiple schedules can overlap (highest desiredReplicas wins)
@@ -578,7 +575,7 @@ kedaAutoscaling:
       #   start: "0 8 * * 1-5"      # 8 AM Monday-Friday
       #   end: "0 18 * * 1-5"       # 6 PM Monday-Friday
       #   desiredReplicas: 5
-      # 
+      #
       # - name: "weekend-scale-down"
       #   start: "0 0 * * 6-7"      # Midnight Saturday-Sunday
       #   end: "0 23 * * 6-7"       # 11 PM Saturday-Sunday
@@ -597,6 +594,36 @@ kedaAutoscaling:
       # │ │ │ │ ┌───────────── day of week (0 - 6) (Sunday to Saturday)
       # │ │ │ │ │
       # * * * * *
+
+    # ==========================================================================
+    # External Scaler
+    # ==========================================================================
+    # Scales based on an external KEDA scaler via gRPC
+    # The entire metadata block is forwarded to the scaler via
+    # ScaledObjectRef.scalerMetadata, so any key-value pairs the external
+    # scaler expects can be added here.
+    # Requires: An external scaler service deployed in the cluster
+    # See: https://keda.sh/docs/2.19/scalers/external/
+
+    external:
+      # -- Enable external scaler triggers
+      enabled: false
+
+      # -- List of external scaler trigger definitions
+      # Each entry produces a separate KEDA external trigger in the ScaledObject.
+      # The metadata map of each entry is forwarded 1:1 to the scaler via gRPC.
+      # scalerAddress is REQUIRED in every entry; all other keys depend on the
+      # external scaler implementation.
+      scalers: []
+      # Example — multiple campaigns on the same scaler:
+      # - metadata:
+      #     scalerAddress: "campaign-scaler.keda.svc.cluster.local:6000"
+      #     campaignName: "fifa-worldcup-2026"
+      #     targetReplicas: "100"
+      # - metadata:
+      #     scalerAddress: "campaign-scaler.keda.svc.cluster.local:6000"
+      #     campaignName: "black-friday-2026"
+      #     targetReplicas: "50"
 
 # -- Kong container resource limits and requests
 resources:
@@ -661,7 +688,7 @@ setupJobs:
     privileged: false
     capabilities:
       drop:
-      - ALL
+        - ALL
 
 # Kong plugin configuration
 plugins:
@@ -675,7 +702,7 @@ plugins:
     privileged: false
     capabilities:
       drop:
-      - ALL
+        - ALL
   # -- Additional Kong plugins to enable (beyond bundled and jwt-keycloak)
   enabled:
     - rate-limiting-merged
@@ -683,14 +710,14 @@ plugins:
   acl:
     # -- Plugin ID for Kong configuration
     pluginId: bc823d55-83b5-4184-b03f-ce63cd3b75c7
-      
+
   jwtKeycloak:
     # -- Enable JWT Keycloak plugin
     enabled: true
     # -- Plugin ID for Kong configuration
     pluginId: b864d58b-7183-4889-8b32-0b92d6c4d513
     # -- Allowed identity provider issuer URLs (used for authenticating Admin API requests from the Rover realm)
-    allowedIss: 
+    allowedIss:
       - https://<your-iris-host>/auth/realms/rover
 
   prometheus:
@@ -798,20 +825,20 @@ irixBrokerRoute:
 jumper:
   # -- Enable Jumper container deployment
   enabled: true
-  
+
   # -- Jumper image configuration (inherits from global.image)
   image:
     # registry: ""  # Override global.image.registry
     # namespace: ""  # Override global.image.namespace
     repository: gateway-jumper
     tag: "4.6.0"
-  
+
   # -- Image pull policy for Jumper container
   imagePullPolicy: IfNotPresent
-  
+
   # -- Jumper container port
   port: 8080
-  
+
   # -- Issuer service URL for gateway token issuance (your gateway's auth realm endpoint)
   issuerUrl: https://<your-gateway-host>/auth/realms/default
   # -- Tracing collector URL (optional)
@@ -867,7 +894,7 @@ jumper:
     privileged: false
     capabilities:
       drop:
-      - ALL
+        - ALL
   # Zone health monitoring configuration (requires Redis)
   zoneHealth:
     # -- Default health status when Redis is unavailable
@@ -914,14 +941,14 @@ jumper:
 issuerService:
   # -- Enable Issuer Service container deployment
   enabled: true
-  
+
   # -- Issuer Service image configuration (inherits from global.image)
   image:
     # registry: ""  # Override global.image.registry
     # namespace: ""  # Override global.image.namespace
     repository: gateway-issuer-service-go
     tag: "2.3.2"
-  
+
   # -- Image pull policy for Issuer Service container
   imagePullPolicy: IfNotPresent
 
@@ -962,7 +989,7 @@ issuerService:
     privileged: false
     capabilities:
       drop:
-      - ALL
+        - ALL
 
   # -- Additional environment variables for Issuer Service container
   #- {name: foo, value: bar}
@@ -981,14 +1008,14 @@ issuerService:
 circuitbreaker:
   # -- Enable circuit breaker component deployment
   enabled: false
-  
+
   # -- Circuit breaker image configuration (inherits from global.image)
   image:
     # registry: ""  # Override global.image.registry
     # namespace: ""  # Override global.image.namespace
     repository: gateway-circuitbreaker
     tag: "2.1.0"
-  
+
   # -- Image pull policy for circuit breaker container
   imagePullPolicy: IfNotPresent
 
@@ -1007,7 +1034,7 @@ circuitbreaker:
     privileged: false
     capabilities:
       drop:
-      - ALL
+        - ALL
 
   # -- Circuit breaker container resource limits and requests
   resources:
@@ -1026,17 +1053,17 @@ postgresql:
     # namespace: ""  # Override global.image.namespace
     repository: postgresql
     tag: "16.5"
-  
+
   # -- Image pull policy for PostgreSQL container
   imagePullPolicy: IfNotPresent
-  
+
   # -- Pod security context for PostgreSQL
   podSecurityContext:
     fsGroup: 999
     supplementalGroups: [999]
     seccompProfile:
       type: RuntimeDefault
-  
+
   # -- Container security context for PostgreSQL
   containerSecurityContext:
     runAsUser: 999
@@ -1047,20 +1074,20 @@ postgresql:
     privileged: false
     capabilities:
       drop:
-      - ALL
-  
+        - ALL
+
   # -- Database admin password
   #adminPassword: "changeme"
-  
+
   # -- Maximum number of client connections
   maxConnections: "100"
-  
+
   # -- Shared memory buffer size for data caching
   sharedBuffers: "32MB"
-  
+
   # -- Maximum prepared transactions (0 disables prepared transactions)
   maxPreparedTransactions: "0"
-  
+
   # -- PostgreSQL container resource limits and requests
   resources:
     requests:
@@ -1069,7 +1096,7 @@ postgresql:
     limits:
       cpu: 100m
       memory: 500Mi
-  
+
   persistence:
     # -- Keep PVC on chart deletion
     keepOnDelete: false
@@ -1080,8 +1107,8 @@ postgresql:
       requests:
         storage: 1Gi
     # -- Data directory mount path
-    mountDir: '/var/lib/postgresql/data'
-  
+    mountDir: "/var/lib/postgresql/data"
+
   # -- Additional deployment annotations
   deployment:
     annotations: {}
@@ -1201,11 +1228,10 @@ imageVerification:
       cpu: 200m
       memory: 128Mi
 
-
 # ============================================================================
 # Argo Rollouts Configuration
 # ============================================================================
-# Argo Rollouts provides advanced deployment capabilities with progressive 
+# Argo Rollouts provides advanced deployment capabilities with progressive
 # delivery strategies like canary and blue-green deployments.
 #
 # Prerequisites:
@@ -1219,7 +1245,7 @@ imageVerification:
 argoRollouts:
   # -- Enable Argo Rollouts progressive delivery (replaces standard Deployment)
   enabled: false
-  
+
   # -- Progress deadline in seconds. If pods don't become ready within this time,
   # the rollout will be marked as degraded. Default: 1200 (20 minutes)
   progressDeadlineSeconds: 1200
@@ -1228,7 +1254,6 @@ argoRollouts:
   # When true, the rollout will abort and rollback to the previous version.
   progressDeadlineAbort: true
 
-  
   workloadRef:
     # -- Scale-down strategy for workloadRef (progressively or immediately)
     scaleDown: progressively
@@ -1241,7 +1266,7 @@ argoRollouts:
   strategy:
     # -- Deployment strategy type: "canary" or "blueGreen"
     type: canary
-    
+
     # -- Canary strategy configuration
     canary:
       # -- Additional canary deployment properties
@@ -1273,7 +1298,7 @@ argoRollouts:
             duration: 1m
         - setWeight: 60
         - pause:
-            duration: 1m            
+            duration: 1m
         - setWeight: 80
         - pause:
             duration: 1m
@@ -1282,7 +1307,7 @@ argoRollouts:
       # Analysis Configuration
       # ============================================================================
       # Optional background analysis during canary deployment
-      
+
       # -- Background analysis configuration
       analysis:
         # -- AnalysisTemplate names for background analysis
@@ -1302,16 +1327,16 @@ argoRollouts:
   # Analysis Templates Configuration
   # ============================================================================
   # Define metrics and success criteria for automated rollout validation
-  
+
   analysisTemplates:
     # -- Enable creation of AnalysisTemplates
     enabled: true
-    
+
     # ============================================================================
     # Error Rate Analysis Template
     # ============================================================================
     # Validates that error rate stays below acceptable threshold
-    
+
     errorRate:
       # -- Enable error rate analysis
       enabled: false
@@ -1336,12 +1361,12 @@ argoRollouts:
       # -- Prometheus server address (must be accessible)
       # Example: "http://prometheus.monitoring.svc.cluster.local:8427"
       prometheusAddress: ""
-      
+
       # -- Prometheus Basic Auth authentication configuration
       authentication:
         # -- Enable authentication for Prometheus queries
         enabled: true
-        
+
         # -- Secret name containing Prometheus credentials (must exist in same namespace as Rollout)
         # Example secret:
         #   apiVersion: v1
@@ -1353,7 +1378,7 @@ argoRollouts:
         #     username: "my-username"
         #     password: "my-password"
         secretName: "victoria-metrics-secret"
-        
+
         # -- Secret key for base64 encoded user:password Basic Auth header
         basicKey: "basic-auth"
 
@@ -1361,7 +1386,7 @@ argoRollouts:
     # Success Rate Analysis Template
     # ============================================================================
     # Validates that success rate stays above acceptable threshold
-    
+
     successRate:
       # -- Enable success rate analysis
       enabled: true
@@ -1385,15 +1410,15 @@ argoRollouts:
 
       # -- Prometheus server address
       prometheusAddress: ""
-      
+
       # -- Prometheus Basic Auth authentication configuration
       authentication:
         # -- Enable authentication for Prometheus queries
         enabled: true
-        
+
         # -- Secret name containing Prometheus credentials
         secretName: "victoria-metrics-secret"
-        
+
         # -- Secret key for base64 encoded user:password Basic Auth header
         basicKey: "basic-auth"
 
@@ -1407,7 +1432,7 @@ argoRollouts:
 networkPolicy:
   # -- Enable NetworkPolicy for the gateway pods
   enabled: false
-  
+
   # -- Custom ingress rules (if not set, default rules based on enabled components are used)
   # ingress:
   #   - from:
@@ -1417,7 +1442,7 @@ networkPolicy:
   #     ports:
   #       - port: 8000
   #         protocol: TCP
-  
+
   # -- Custom egress rules (if not set, all egress is allowed)
   # egress:
   #   - to:


### PR DESCRIPTION
Add a generic KEDA external scaler trigger to the ScaledObject template. The metadata map is forwarded as-is to the scaler service via gRPC, requiring only scalerAddress; all other keys are scaler-specific. Disabled by default, intended to be configured via Argo CD helmValues.