### PR TITLE
feat: add blockedIssuers zone-wide issuer blocklist to jwt-keycloak config

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,7 +905,8 @@ The following table provides a comprehensive list of all configurable parameters
 | plugins.acl.pluginId | string | `"bc823d55-83b5-4184-b03f-ce63cd3b75c7"` | Plugin ID for Kong configuration |
 | plugins.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":100}` | Container security context for plugin containers |
 | plugins.enabled | list | `["rate-limiting-merged"]` | Additional Kong plugins to enable (beyond bundled and jwt-keycloak) |
-| plugins.jwtKeycloak.allowedIss | list | `["https://<your-iris-host>/auth/realms/rover"]` | Allowed identity provider issuer URLs (used for authenticating Admin API requests from the Rover realm) |
+| plugins.jwtKeycloak.allowedIss | list | `["https://<your-iris-host>/auth/realms/rover"]` | Allowed issuers for the admin-api route JWT validation (Rover realm only). Configured per-route via the Kong Admin API by the chart setup job. |
+| plugins.jwtKeycloak.blockedIssuers | list | `[]` | Zone-wide issuer blocklist. Tokens from these issuers are rejected on ALL routes regardless of per-route allowedIss. Takes effect on Kong restart/redeploy only. Used for emergency revocation of compromised consumer zone gateway issuers without requiring full route reprocessing by Rover. |
 | plugins.jwtKeycloak.enabled | bool | `true` | Enable JWT Keycloak plugin |
 | plugins.jwtKeycloak.pluginId | string | `"b864d58b-7183-4889-8b32-0b92d6c4d513"` | Plugin ID for Kong configuration |
 | plugins.prometheus.enabled | bool | `true` | Enable Prometheus metrics plugin |

--- a/README.md
+++ b/README.md
@@ -773,8 +773,8 @@ The following table provides a comprehensive list of all configurable parameters
 | hpaAutoscaling.cpuUtilizationPercentage | int | `80` | Target CPU utilization percentage |
 | hpaAutoscaling.maxReplicas | int | `10` | Maximum number of replicas |
 | hpaAutoscaling.minReplicas | int | `3` | Minimum number of replicas |
-| image | object | `{"repository":"gateway-kong","tag":"1.5.0"}` | Kong Gateway image configuration (inherits from global.image) |
-| image.tag | string | `"1.5.0"` | Kong Gateway image tag |
+| image | object | `{"repository":"gateway-kong","tag":"1.6.1"}` | Kong Gateway image configuration (inherits from global.image) |
+| image.tag | string | `"1.6.1"` | Kong Gateway image tag |
 | imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for Kong container |
 | imageVerification.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000}` | Container security context for verification InitContainer |
 | imageVerification.enabled | bool | `false` | Enable cosign image signature verification (disable if using Kyverno policy) |

--- a/templates/_kong.tpl
+++ b/templates/_kong.tpl
@@ -445,6 +445,10 @@ false
   value: {{ .Values.adminApi.errorLog | quote }}
 {{- end }}
 {{- include "kong.kongLuaSslTrustedCertificatePath" . -}}
+{{- if .Values.plugins.jwtKeycloak.blockedIssuers }}
+- name: JWT_KEYCLOAK_BLOCKED_ISSUERS
+  value: {{ join "," .Values.plugins.jwtKeycloak.blockedIssuers | quote }}
+{{- end }}
 {{- end }}
 
 {{- define "kong.kongLuaSslTrustedCertificatePath" -}}

--- a/values.yaml
+++ b/values.yaml
@@ -717,9 +717,11 @@ plugins:
     enabled: true
     # -- Plugin ID for Kong configuration
     pluginId: b864d58b-7183-4889-8b32-0b92d6c4d513
-    # -- Allowed identity provider issuer URLs (used for authenticating Admin API requests from the Rover realm)
+    # -- Allowed issuers for the admin-api route JWT validation (Rover realm only). Configured per-route via the Kong Admin API by the chart setup job.
     allowedIss:
       - https://<your-iris-host>/auth/realms/rover
+    # -- Zone-wide issuer blocklist. Tokens from these issuers are rejected on ALL routes regardless of per-route allowedIss. Takes effect on Kong restart/redeploy only. Used for emergency revocation of compromised consumer zone gateway issuers without requiring full route reprocessing by Rover.
+    blockedIssuers: []
 
   prometheus:
     # -- Enable Prometheus metrics plugin

--- a/values.yaml
+++ b/values.yaml
@@ -99,7 +99,7 @@ image:
   # namespace: ""  # Override global.image.namespace
   repository: gateway-kong
   # -- Kong Gateway image tag
-  tag: "1.5.0"
+  tag: "1.6.1"
 
 # -- Image pull policy for Kong container
 imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Context

Exposes the `JWT_KEYCLOAK_BLOCKED_ISSUERS` env var introduced in telekom/kong-plugin-jwt-keycloak#12 as a chart value, as part of the Mesh LMS security mitigation (DHEI-19942 / DHEI-19943).

When a consumer zone gateway key is compromised, `plugins.jwtKeycloak.blockedIssuers` can be set to a list of issuer URLs and Kong redeployed. This blocks tokens from those issuers zone-wide immediately, without requiring Rover to reprocess every affected proxy route.

See telekom/kong-plugin-jwt-keycloak#12 for the blockedIssuers plugin implementation and telekom/kong-plugin-jwt-keycloak#13 for the `allowed_iss` exact-match security fix included in 1.8.1.

## Changes

- `values.yaml` — add `plugins.jwtKeycloak.blockedIssuers: []` with clarifying comments distinguishing it from `allowedIss` (which configures the admin-api route only)
- `templates/_kong.tpl` — conditionally emit `JWT_KEYCLOAK_BLOCKED_ISSUERS` env var on the Kong container when the list is non-empty
- `values.yaml` — bump Kong image tag from `1.5.0` to `1.6.1` (picks up `blockedIssuers` support and `allowed_iss` exact-match fix from `gateway-kong-image`)

DHEI-19943