### PR TITLE
chore: remove irixBroker route

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,13 +789,6 @@ The following table provides a comprehensive list of all configurable parameters
 | imageVerification.publicKey.secretRef.name | string | `"cosign-public-key"` | Name of the Secret containing the public key |
 | imageVerification.publicKey.source | string | `"secret"` | Source type: "value" (inline), "configMap", or "secret" |
 | imageVerification.resources | object | `{"limits":{"cpu":"200m","memory":"128Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | Resource limits and requests for verification InitContainer |
-| irixBrokerRoute.enabled | bool | `false` | Enable IRIX broker route |
-| irixBrokerRoute.name | string | `"user-login"` | Route name |
-| irixBrokerRoute.upstream | object | `{"path":"/auth/realms/eni-login","port":80,"protocol":"http","service":"irix-broker"}` | Route hostname (optional, uses default host rules if not set) host: integration.spacegate.telekom.de |
-| irixBrokerRoute.upstream.path | string | `"/auth/realms/eni-login"` | Upstream service path |
-| irixBrokerRoute.upstream.port | int | `80` | Upstream service port |
-| irixBrokerRoute.upstream.protocol | string | `"http"` | Upstream protocol |
-| irixBrokerRoute.upstream.service | string | `"irix-broker"` | Upstream service name |
 | issuerService.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000}` | Container security context for Issuer Service |
 | issuerService.enabled | bool | `true` | Enable Issuer Service container deployment |
 | issuerService.environment | list | `[]` | Additional environment variables for Issuer Service container - {name: foo, value: bar} |

--- a/templates/_kong.tpl
+++ b/templates/_kong.tpl
@@ -594,22 +594,3 @@ admin-api
 {{- $mergedAnnotations | toYaml -}}
 {{ end -}}
 
-{{- define "kong.irixBrokerRoute.spacegateHost" -}}
-{{- if .Values.irixBrokerRoute.host -}}
-{{ .Values.irixBrokerRoute.host -}}
-{{- else -}}
-{{- (first .Values.proxy.ingress.hosts).host -}}
-{{- end -}}
-{{- end -}}
-
-{{- define "kong.irixBrokerRoute.upstreamHost" -}}
-{{- if .Values.irixBrokerRoute.upstream.host -}}
-{{ .Values.irixBrokerRoute.upstream.host -}}
-{{- else -}}
-{{- if .Values.irixBrokerRoute.upstream.namespace -}}
-{{ .Values.irixBrokerRoute.upstream.service | default "iris-broker" }}.{{ .Values.irixBrokerRoute.upstream.namespace -}}
-{{- else -}}
-{{ .Values.irixBrokerRoute.upstream.service | default "iris-broker" }}.{{ .Release.Namespace -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}

--- a/templates/jobs/kong/configuration/configmap.yaml
+++ b/templates/jobs/kong/configuration/configmap.yaml
@@ -120,50 +120,6 @@ data:
           "consumer_match_claim_custom_id" : true
         }
       }'
-    {{- if eq .Values.irixBrokerRoute.enabled true }}
-    echo ""
-    echo "8) Create service (upstream: {{ .Values.irixBrokerRoute.upstream.protocol }}//{{ include "kong.irixBrokerRoute.upstreamHost" . }}:{{ .Values.irixBrokerRoute.upstream.port }})"
-    curl --request PUT \
-      --url {{ $apiUrl }}/services/{{ .Values.irixBrokerRoute.name }} \
-      --header 'Content-Type: application/json' \
-      -u "admin:$X_TARDIS_GATEWAY_ADMIN" \
-      --data \
-      '{
-        "name": "{{ .Values.irixBrokerRoute.name }}",
-        "tags": ["irix-broker","{{ .Values.irixBrokerRoute.name }}"],
-        "protocol": "{{ .Values.irixBrokerRoute.upstream.protocol }}",
-        "host": "{{ include "kong.irixBrokerRoute.upstreamHost" . }}",
-        "port": {{ .Values.irixBrokerRoute.upstream.port }},
-        "path": "{{ .Values.irixBrokerRoute.upstream.path }}"
-      }'
-    echo ""
-    echo "9) Create route (/{{ .Values.irixBrokerRoute.name }}) "
-    curl --request PUT \
-      --url {{ $apiUrl }}/services/{{ .Values.irixBrokerRoute.name }}/routes/{{ .Values.irixBrokerRoute.name }} \
-      --header 'Content-Type: application/json' \
-      -u "admin:$X_TARDIS_GATEWAY_ADMIN" \
-      --data \
-      '{
-        "name": "{{ .Values.irixBrokerRoute.name }}",
-        "tags": ["irix-broker","{{ .Values.irixBrokerRoute.name }}"],
-        "strip_path": true,
-        "preserve_host": true,
-        "protocols": ["http","https"],
-        "methods": ["GET","POST"],
-        "hosts": [
-          {{- if .Values.irixBrokerRoute.host -}}
-          {{ .Values.irixBrokerRoute.host | quote }}
-          {{- else -}}
-          {{- range $index, $element := .Values.proxy.ingress.hosts }}
-          {{ $element.host | quote }}{{- if ne $index (sub (len $.Values.proxy.ingress.hosts) 1) }},{{- end }}
-          {{- end -}}
-          {{- end }}
-        ],
-        "paths": [
-          "/{{ .Values.irixBrokerRoute.name }}"
-        ]
-      }'
-    {{- end -}}
     {{- end -}}
     {{- end -}}
 

--- a/values.yaml
+++ b/values.yaml
@@ -806,28 +806,6 @@ plugins:
     #  <CA certificate in PEM format>
     #  -----END CERTIFICATE-----
 
-# IRIX Broker route configuration (proxy route to IRIX broker service)
-irixBrokerRoute:
-  # -- Enable IRIX broker route
-  enabled: false
-  # -- Route name
-  name: user-login
-  # -- Route hostname (optional, uses default host rules if not set)
-  #host: integration.spacegate.telekom.de
-  upstream:
-    # -- Upstream protocol
-    protocol: http
-    # -- Upstream service name
-    service: irix-broker
-    # -- Upstream service path
-    path: /auth/realms/eni-login
-    # -- Upstream service port
-    port: 80
-    # -- Upstream hostname (optional, for ingress access)
-    #host: integration.spacegate.telekom.de
-    # -- Upstream service namespace (optional, for cross-namespace access)
-    #namespace: integration
-
 # Jumper component for Gateway-to-Gateway communication and Last Mile Security
 jumper:
   # -- Enable Jumper container deployment


### PR DESCRIPTION
irixBroker has been unused for some time and is not in scope of the Open-Telekom-Integration-Platform. Remove the irixBrokerRoute values, helper templates, configmap logic and README documentation.