### PR TITLE
feat: add optional DNS resilience configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,6 +744,8 @@ The following table provides a comprehensive list of all configurable parameters
 | dbUpdateFrequency | int | `10` | Frequency in seconds to poll database for updates |
 | dbUpdatePropagation | int | `0` | Delay in seconds before propagating database updates |
 | disableUpstreamCache | bool | `false` | Disable upstream response caching |
+| dns.dnsConfig | object | `{}` | Custom DNS configuration for the pod. Passed through directly to PodSpec.dnsConfig. Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config |
+| dns.dnsPolicy | string | `"ClusterFirst"` | DNS policy for the pod. Defaults to ClusterFirst. Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy |
 | externalDatabase.ssl | bool | `true` | Enable SSL for external database connections |
 | externalDatabase.sslVerify | bool | `false` | Verify SSL certificates for external database |
 | global.database.database | string | `"kong"` | Database name |

--- a/templates/deployment.yml
+++ b/templates/deployment.yml
@@ -223,6 +223,10 @@ spec:
       {{- include "cosign.keyVolume" $ | nindent 6 }}
       {{- include "cosign.pullSecretVolumes" $ | nindent 6 }}
 {{- end }}
-      dnsPolicy: ClusterFirst
+      dnsPolicy: {{ .Values.dns.dnsPolicy }}
+      {{- if .Values.dns.dnsConfig }}
+      dnsConfig:
+        {{- toYaml .Values.dns.dnsConfig | nindent 8 }}
+      {{- end }}
       restartPolicy: Always
       terminationGracePeriodSeconds: {{ add .Values.global.preStopSleepBase 1 60 }}

--- a/values.yaml
+++ b/values.yaml
@@ -86,6 +86,16 @@ global:
   # -- Base sleep duration in seconds for pre-stop lifecycle hook
   preStopSleepBase: 15
 
+# DNS Configuration (Pod-level)
+# Allows configuration of pod DNS settings to enable optimized external DNS resolution
+dns:
+  # -- DNS policy for the pod. Defaults to ClusterFirst.
+  # Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+  dnsPolicy: ClusterFirst
+  # -- Custom DNS configuration for the pod. Passed through directly to PodSpec.dnsConfig.
+  # Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+  dnsConfig: {}
+
 # List template files that should trigger pod restart when changed
 # Useful for ConfigMaps or Secrets that need immediate propagation
 #templateChangeTriggers:


### PR DESCRIPTION
Introduce pod-level DNS tuning and JVM DNS cache settings to improve DNS resilience for Stargate pods, especially under high traffic or during CoreDNS instability.

Layer 1 - Kubernetes DNS Configuration (pod-level):
- Add dns.enabled flag (default: false) for opt-in per environment
- Configure ndots:1 to reduce search-domain queries for actually mostly external domains
- Set DNS timeout to 2s and retry attempts to 3
- Enable single-request-reopen to prevent DNS port reuse issues
- dnsConfig block in deployment template only renders when dns.enabled=true