### PR TITLE
feat!: replace imageVerification.publicKey with publicKeys list for multi-key support

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,74 @@ SPDX-License-Identifier: CC0-1.0
 
 This document provides guidance for upgrading between versions of the Gateway Helm chart.
 
+## From 9.x.x to 10.0.0
+
+### `imageVerification.publicKey` replaced by `imageVerification.publicKeys` (BREAKING)
+
+The singular `imageVerification.publicKey` field has been replaced with a list
+`imageVerification.publicKeys`. This enables verifying images against multiple
+public keys, where verification succeeds if **any** key validates the signature
+(useful for key rotation).
+
+**Before:**
+```yaml
+imageVerification:
+  enabled: true
+  publicKey:
+    source: secret
+    secretRef:
+      name: cosign-public-key
+      key: cosign.pub
+```
+
+**After:**
+```yaml
+imageVerification:
+  enabled: true
+  publicKeys:
+    - source: secret
+      secretRef:
+        name: cosign-public-key
+        key: cosign.pub
+```
+
+All three source types are supported in the list:
+
+```yaml
+imageVerification:
+  enabled: true
+  publicKeys:
+    # Inline PEM (creates a ConfigMap automatically)
+    - source: value
+      value: |
+        -----BEGIN PUBLIC KEY-----
+        MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE...
+        -----END PUBLIC KEY-----
+
+    # From an existing ConfigMap
+    - source: configMap
+      configMapRef:
+        name: my-cosign-keys
+        key: cosign.pub
+
+    # From an existing Secret
+    - source: secret
+      secretRef:
+        name: cosign-public-key
+        key: cosign.pub
+```
+
+### `configMapRef.key` and `secretRef.key` are now required at render time
+
+Previously, omitting `configMapRef.key` (for `source: configMap` entries) or
+`secretRef.key` (for `source: secret` entries) was not caught at
+`helm template`/`helm install` time and only failed at pod startup.
+The new validation rejects the configuration at render time. Ensure
+`configMapRef.key` is set on every `source: configMap` entry and
+`secretRef.key` is set on every `source: secret` entry.
+
+---
+
 ## From 8.x.x to 9.x.x
 
 Version 9.0.0 introduces several breaking changes that modernize the chart structure and align with Kubernetes best practices. Review all changes carefully before upgrading.

--- a/templates/_cosign.tpl
+++ b/templates/_cosign.tpl
@@ -222,7 +222,7 @@ Returns the InitContainer for cosign image verification.
   {{- include "cosign.dockerConfigVolumeMount" . | nindent 2 }}
   {{- include "cosign.pullSecretVolumeMounts" . | nindent 2 }}
   command:
-  - /bin/sh
+  - /bin/bash
   - -c
   - |
     FAILED=0

--- a/templates/_cosign.tpl
+++ b/templates/_cosign.tpl
@@ -32,77 +32,175 @@ Returns a list of all enabled container images for verification.
 {{- end -}}
 
 {{/*
-Validates that exactly one public key source is configured.
+Validates that publicKeys is a non-empty list with valid entries.
+Each entry must have a valid source and the required fields for that source.
 */}}
-{{- define "cosign.validatePublicKey" -}}
+{{- define "cosign.validatePublicKeys" -}}
 {{- if .Values.imageVerification.enabled -}}
-{{- $source := .Values.imageVerification.publicKey.source -}}
+{{- if not .Values.imageVerification.publicKeys -}}
+{{- fail "imageVerification.publicKeys must be a non-empty list" -}}
+{{- end -}}
+{{- range $i, $entry := .Values.imageVerification.publicKeys -}}
+{{- $source := $entry.source -}}
 {{- if not (or (eq $source "value") (eq $source "configMap") (eq $source "secret")) -}}
-{{- fail "imageVerification.publicKey.source must be one of: value, configMap, secret" -}}
+{{- fail (printf "imageVerification.publicKeys[%d].source is missing or invalid (got %q); must be one of: value, configMap, secret" $i $source) -}}
 {{- end -}}
-{{- if and (eq $source "value") (not .Values.imageVerification.publicKey.value) -}}
-{{- fail "imageVerification.publicKey.value is required when source is 'value'" -}}
+{{- if and (eq $source "value") (not $entry.value) -}}
+{{- fail (printf "imageVerification.publicKeys[%d].value is required when source is 'value'" $i) -}}
 {{- end -}}
-{{- if and (eq $source "configMap") (not .Values.imageVerification.publicKey.configMapRef.name) -}}
-{{- fail "imageVerification.publicKey.configMapRef.name is required when source is 'configMap'" -}}
+{{- if and (eq $source "configMap") (not $entry.configMapRef.name) -}}
+{{- fail (printf "imageVerification.publicKeys[%d].configMapRef.name is required when source is 'configMap'" $i) -}}
 {{- end -}}
-{{- if and (eq $source "secret") (not .Values.imageVerification.publicKey.secretRef.name) -}}
-{{- fail "imageVerification.publicKey.secretRef.name is required when source is 'secret'" -}}
+{{- if and (eq $source "configMap") (not $entry.configMapRef.key) -}}
+{{- fail (printf "imageVerification.publicKeys[%d].configMapRef.key is required when source is 'configMap'" $i) -}}
+{{- end -}}
+{{- if and (eq $source "secret") (not $entry.secretRef.name) -}}
+{{- fail (printf "imageVerification.publicKeys[%d].secretRef.name is required when source is 'secret'" $i) -}}
+{{- end -}}
+{{- if and (eq $source "secret") (not $entry.secretRef.key) -}}
+{{- fail (printf "imageVerification.publicKeys[%d].secretRef.key is required when source is 'secret'" $i) -}}
 {{- end -}}
 {{- end -}}
-{{- end -}}
-
-{{/*
-Returns the key filename to use in the mounted volume.
-*/}}
-{{- define "cosign.publicKeyFilename" -}}
-{{- $source := .Values.imageVerification.publicKey.source -}}
-{{- if eq $source "value" -}}
-cosign.pub
-{{- else if eq $source "configMap" -}}
-{{- .Values.imageVerification.publicKey.configMapRef.key -}}
-{{- else -}}
-{{- .Values.imageVerification.publicKey.secretRef.key -}}
 {{- end -}}
 {{- end -}}
 
 {{/*
-Returns the volume configuration for the cosign public key.
+Returns the volume name for a public key entry.
+Accepts: (dict "source" <string> "i" <int> "prefix" <string>)
+
+  source=value     → "<prefix>-cosign-public-key"  (shared ConfigMap; index unused)
+  source=configMap → "cosign-key-cm-<i>"
+  source=secret    → "cosign-key-sec-<i>"
 */}}
-{{- define "cosign.keyVolume" -}}
-{{- $source := .Values.imageVerification.publicKey.source -}}
-- name: cosign-key
-{{- if eq $source "value" }}
+{{- define "cosign.keyVolumeName" -}}
+{{- if eq .source "value" -}}
+{{- .prefix }}-cosign-public-key
+{{- else if eq .source "configMap" -}}
+cosign-key-cm-{{ .i }}
+{{- else if eq .source "secret" -}}
+cosign-key-sec-{{ .i }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns the mount path for a public key entry.
+Accepts: (dict "source" <string> "i" <int>)
+
+  source=value     → /cosign/values
+  source=configMap → /cosign/cm-<i>
+  source=secret    → /cosign/sec-<i>
+*/}}
+{{- define "cosign.keyMountPath" -}}
+{{- if eq .source "value" -}}
+/cosign/values
+{{- else if eq .source "configMap" -}}
+/cosign/cm-{{ .i }}
+{{- else if eq .source "secret" -}}
+/cosign/sec-{{ .i }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns the volume definitions for all public key entries.
+All source=value entries share a single ConfigMap volume (emitted once).
+source=configMap and source=secret each get an individual volume per entry.
+*/}}
+{{- define "cosign.keyVolumes" -}}
+{{- $state := dict "hasValueSource" false -}}
+{{- range $i, $entry := .Values.imageVerification.publicKeys -}}
+{{- $ctx := dict "source" $entry.source "i" $i "prefix" $.Release.Name -}}
+{{- if eq $entry.source "value" -}}
+{{- if not (get $state "hasValueSource") }}
+- name: {{ include "cosign.keyVolumeName" $ctx }}
   configMap:
-    name: {{ .Release.Name }}-cosign-public-key
-{{- else if eq $source "configMap" }}
+    name: {{ $.Release.Name }}-cosign-public-key
+{{- end -}}
+{{- $_ := set $state "hasValueSource" true -}}
+{{- else if eq $entry.source "configMap" }}
+- name: {{ include "cosign.keyVolumeName" $ctx }}
   configMap:
-    name: {{ .Values.imageVerification.publicKey.configMapRef.name }}
-{{- else }}
+    name: {{ $entry.configMapRef.name }}
+{{- else if eq $entry.source "secret" }}
+- name: {{ include "cosign.keyVolumeName" $ctx }}
   secret:
-    secretName: {{ .Values.imageVerification.publicKey.secretRef.name }}
-{{- end }}
+    secretName: {{ $entry.secretRef.name }}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
-Returns the volume configurations for imagePullSecrets (for cosign login).
+Returns the volumeMount entries for all public key entries.
+All source=value entries share a single mount (emitted once).
 */}}
-{{- define "cosign.pullSecretVolumes" -}}
+{{- define "cosign.keyVolumeMounts" -}}
+{{- $state := dict "hasValueSource" false -}}
+{{- range $i, $entry := .Values.imageVerification.publicKeys -}}
+{{- $ctx := dict "source" $entry.source "i" $i "prefix" $.Release.Name -}}
+{{- if eq $entry.source "value" -}}
+{{- if not (get $state "hasValueSource") }}
+- name: {{ include "cosign.keyVolumeName" $ctx }}
+  mountPath: {{ include "cosign.keyMountPath" $ctx }}
+  readOnly: true
+{{- end -}}
+{{- $_ := set $state "hasValueSource" true -}}
+{{- else if eq $entry.source "configMap" }}
+- name: {{ include "cosign.keyVolumeName" $ctx }}
+  mountPath: {{ include "cosign.keyMountPath" $ctx }}
+  readOnly: true
+{{- else if eq $entry.source "secret" }}
+- name: {{ include "cosign.keyVolumeName" $ctx }}
+  mountPath: {{ include "cosign.keyMountPath" $ctx }}
+  readOnly: true
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns the emptyDir volume used as the cosign DOCKER_CONFIG directory.
+*/}}
+{{- define "cosign.dockerConfigVolume" -}}
 - name: cosign-docker-config
   emptyDir: {}
-{{- if .Values.global.imagePullSecrets }}
-{{- range $index, $secret := .Values.global.imagePullSecrets }}
+{{- end -}}
+
+{{/*
+Returns the volumeMount entry for the cosign DOCKER_CONFIG emptyDir.
+*/}}
+{{- define "cosign.dockerConfigVolumeMount" -}}
+- name: cosign-docker-config
+  mountPath: /tmp/docker
+{{- end -}}
+
+{{/*
+Returns the Secret volume definitions for imagePullSecrets.
+*/}}
+{{- define "cosign.pullSecretVolumes" -}}
+{{- if .Values.global.imagePullSecrets -}}
+{{- range $i, $secret := .Values.global.imagePullSecrets -}}
 {{- $secretName := "" -}}
 {{- if not (kindIs "string" $secret) -}}
 {{- $secretName = printf "%s-%s" $.Release.Name $secret.name -}}
 {{- else -}}
 {{- $secretName = $secret -}}
 {{- end }}
-- name: pull-secret-{{ $index }}
+- name: pull-secret-{{ $i }}
   secret:
     secretName: {{ $secretName }}
-{{- end }}
-{{- end }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns the volumeMount entries for imagePullSecrets.
+*/}}
+{{- define "cosign.pullSecretVolumeMounts" -}}
+{{- if .Values.global.imagePullSecrets -}}
+{{- range $i, $secret := .Values.global.imagePullSecrets }}
+- name: pull-secret-{{ $i }}
+  mountPath: /pull-secrets/{{ $i }}
+  readOnly: true
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -120,18 +218,9 @@ Returns the InitContainer for cosign image verification.
   - name: DOCKER_CONFIG
     value: /tmp/docker
   volumeMounts:
-  - name: cosign-key
-    mountPath: /cosign
-    readOnly: true
-  - name: cosign-docker-config
-    mountPath: /tmp/docker
-{{- if .Values.global.imagePullSecrets }}
-{{- range $index, $secret := .Values.global.imagePullSecrets }}
-  - name: pull-secret-{{ $index }}
-    mountPath: /pull-secrets/{{ $index }}
-    readOnly: true
-{{- end }}
-{{- end }}
+  {{- include "cosign.keyVolumeMounts" . | nindent 2 }}
+  {{- include "cosign.dockerConfigVolumeMount" . | nindent 2 }}
+  {{- include "cosign.pullSecretVolumeMounts" . | nindent 2 }}
   command:
   - /bin/sh
   - -c
@@ -141,66 +230,158 @@ Returns the InitContainer for cosign image verification.
 
     echo "=== Cosign Image Verification (mode: $VERIFICATION_MODE) ==="
 
-    # Function to extract auth from docker config for a registry
+    # Function to extract auth from docker config for a registry.
+    # Handles both plain hostnames and host:port registries.
     extract_auth() {
       CONFIG_FILE="$1"
       REGISTRY="$2"
-      cat "$CONFIG_FILE" | grep -o "\"$REGISTRY\"[^}]*" | grep -o '"auth":"[^"]*"' | cut -d'"' -f4 || true
+      # Use jq for reliable JSON parsing if available; fall back to grep.
+      if command -v jq >/dev/null 2>&1; then
+        jq -r --arg reg "$REGISTRY" '.auths[$reg].auth // empty' "$CONFIG_FILE" 2>/dev/null || true
+      else
+        # Escape regex metacharacters in REGISTRY for use in a BRE grep pattern.
+        ESCAPED_REG=$(printf '%s\n' "$REGISTRY" | sed 's/[.[\*^$]/\\&/g')
+        cat "$CONFIG_FILE" | grep -o "\"$ESCAPED_REG\"[^}]*" | grep -o '"auth":"[^"]*"' | cut -d'"' -f4 || true
+      fi
     }
 
-    echo "=== Verifying images ==="
-    for IMAGE in $(echo "$IMAGES" | tr -d '[]"' | tr ',' ' '); do
-      echo "Verifying: $IMAGE"
-      REGISTRY=$(echo "$IMAGE" | cut -d'/' -f1)
-      IMAGE_PROCESSED=0
+    # Extract the registry host (including port if present) from an image reference.
+    # e.g. "mtr.devops.telekom.de:443/myimage:tag" -> "mtr.devops.telekom.de:443"
+    # e.g. "ghcr.io/myimage:tag" -> "ghcr.io"
+    extract_registry() {
+      IMAGE_REF="$1"
+      # The registry is the first '/'-delimited segment if it looks like a hostname.
+      # A hostname contains a '.' (e.g. ghcr.io) or a numeric port suffix (e.g. host:5000).
+      # An image:tag without a '/' must NOT be treated as a host:port registry.
+      FIRST=$(echo "$IMAGE_REF" | cut -d'/' -f1)
+      case "$FIRST" in
+        *.*) echo "$FIRST" ;;  # contains a dot → registry hostname
+        *:*) # contains a colon — only treat as host:port if the suffix is purely numeric
+             PORT="${FIRST##*:}"
+             case "$PORT" in
+               *[!0-9]*) echo "" ;;   # non-numeric suffix → it's a tag, not a port
+               *)         echo "$FIRST" ;;
+             esac ;;
+        *)   echo "" ;;  # no explicit registry (Docker Hub short-form)
+      esac
+    }
 
-      # Try each pull secret until verification succeeds
+    # Try to verify an image with a single key file, with registry auth.
+    # Returns 0 if verified, 1 if all pull secrets failed with UNAUTHORIZED
+    # (auth problem, not a key mismatch), 2 if signature invalid/other failure.
+    verify_with_auth() {
+      IMAGE="$1"
+      KEY_FILE="$2"
+      REGISTRY=$(extract_registry "$IMAGE")
+      # Docker Hub images have no explicit registry; credentials are stored under the v1 endpoint.
+      if [ -z "$REGISTRY" ]; then
+        REGISTRY="https://index.docker.io/v1/"
+      fi
+
+      # Clear any credentials left over from a previous key iteration.
+      rm -f "$DOCKER_CONFIG/config.json"
+
+      AUTH_ATTEMPTED=0
+      VERIFY_FAILED=0
+
+      # Try each pull secret for registry auth
       for SECRET_DIR in /pull-secrets/*; do
-        if [ -d "$SECRET_DIR" ]; then
-          if [ -f "$SECRET_DIR/.dockerconfigjson" ]; then
-            CONFIG_FILE="$SECRET_DIR/.dockerconfigjson"
-          elif [ -f "$SECRET_DIR/config.json" ]; then
-            CONFIG_FILE="$SECRET_DIR/config.json"
-          else
+        [ -d "$SECRET_DIR" ] || continue
+        if [ -f "$SECRET_DIR/.dockerconfigjson" ]; then
+          CONFIG_FILE="$SECRET_DIR/.dockerconfigjson"
+        elif [ -f "$SECRET_DIR/config.json" ]; then
+          CONFIG_FILE="$SECRET_DIR/config.json"
+        else
+          continue
+        fi
+
+        AUTH=$(extract_auth "$CONFIG_FILE" "$REGISTRY")
+        if [ -n "$AUTH" ]; then
+          DECODED=$(echo "$AUTH" | base64 -d 2>/dev/null || true)
+          if [ -z "$DECODED" ]; then
+            echo "  (warning: auth token for $REGISTRY in $SECRET_DIR is empty or malformed, skipping)"
             continue
           fi
+          USERNAME=$(echo "$DECODED" | cut -d':' -f1)
+          PASSWORD=$(echo "$DECODED" | cut -d':' -f2-)
 
-          AUTH=$(extract_auth "$CONFIG_FILE" "$REGISTRY")
-          if [ -n "$AUTH" ]; then
-            DECODED=$(echo "$AUTH" | base64 -d 2>/dev/null || true)
-            if [ -n "$DECODED" ]; then
-              USERNAME=$(echo "$DECODED" | cut -d':' -f1)
-              PASSWORD=$(echo "$DECODED" | cut -d':' -f2-)
+          rm -f "$DOCKER_CONFIG/config.json"
+          if ! cosign login "$REGISTRY" -u "$USERNAME" -p "$PASSWORD" >/dev/null 2>&1; then
+            echo "  (warning: cosign login failed for $REGISTRY with secret in $SECRET_DIR)"
+          fi
+          AUTH_ATTEMPTED=1
 
-              # Clear previous credentials and login
-              rm -f "$DOCKER_CONFIG/config.json"
-              cosign login "$REGISTRY" -u "$USERNAME" -p "$PASSWORD" >/dev/null 2>&1 || true
+          OUTPUT=$(cosign verify --insecure-ignore-tlog=true --key "$KEY_FILE" "$IMAGE" 2>&1)
+          EXIT_CODE=$?
 
-              # Try verification
-              OUTPUT=$(cosign verify --insecure-ignore-tlog=true --key /cosign/{{ include "cosign.publicKeyFilename" . }} "$IMAGE" 2>&1)
-              EXIT_CODE=$?
-
-              if [ $EXIT_CODE -eq 0 ]; then
-                echo "✓ $IMAGE: signature valid"
-                IMAGE_PROCESSED=1
-                break
-              elif echo "$OUTPUT" | grep -q "UNAUTHORIZED"; then
-                echo "  (auth failed with secret in $SECRET_DIR, trying next...)"
-                continue
-              else
-                echo "✗ $IMAGE: signature verification FAILED"
-                echo "$OUTPUT"
-                FAILED=1
-                IMAGE_PROCESSED=1
-                break
-              fi
-            fi
+          if [ $EXIT_CODE -eq 0 ]; then
+            return 0
+          elif [ $EXIT_CODE -ne 0 ] && echo "$OUTPUT" | grep -qiE "(UNAUTHORIZED|401 Unauthorized|403 Forbidden|no basic auth credentials|authentication required|access denied)"; then
+            echo "  (auth failed with secret in $SECRET_DIR, trying next...)"
+            continue
+          else
+            # Non-auth failure (e.g. signature not found, network error) — try next pull secret
+            # in case a later one produces a cleaner result; record the output for diagnostics.
+            echo "  (non-auth failure with secret in $SECRET_DIR: $(echo "$OUTPUT" | head -1))"
+            VERIFY_FAILED=1
+            continue
           fi
         fi
       done
 
-      if [ "$IMAGE_PROCESSED" -eq 0 ]; then
-        echo "✗ $IMAGE: UNAUTHORIZED with all available secrets"
+      # All pull secrets tried. Determine failure mode.
+      if [ "$AUTH_ATTEMPTED" -eq 1 ] && [ "$VERIFY_FAILED" -eq 0 ]; then
+        # Every authenticated attempt was rejected by the registry (auth failure).
+        return 1
+      elif [ "$VERIFY_FAILED" -eq 1 ]; then
+        # At least one attempt authenticated but cosign reported a non-auth failure.
+        return 2
+      fi
+
+      # No pull secrets configured or none had credentials for this registry —
+      # try unauthenticated.
+      OUTPUT=$(cosign verify --insecure-ignore-tlog=true --key "$KEY_FILE" "$IMAGE" 2>&1)
+      EXIT_CODE=$?
+      if [ $EXIT_CODE -eq 0 ]; then
+        return 0
+      fi
+      echo "$OUTPUT"
+      return 2
+    }
+
+    echo "=== Verifying images ==="
+    for IMAGE in $(jq -r '.[]' <<<"$IMAGES"); do
+      echo "Verifying: $IMAGE"
+      IMAGE_VERIFIED=0
+      AUTH_FAILED=0
+
+      # Iterate over all mounted key directories and files.
+      # Succeeds (ANY semantics) as soon as one key validates the signature.
+      for KEY_DIR in /cosign/values /cosign/cm-* /cosign/sec-*; do
+        [ -d "$KEY_DIR" ] || continue
+        for KEY_FILE in "$KEY_DIR"/*; do
+          [ -f "$KEY_FILE" ] || continue
+          verify_with_auth "$IMAGE" "$KEY_FILE"
+          RESULT=$?
+          if [ $RESULT -eq 0 ]; then
+            echo "✓ $IMAGE: signature valid (key: $KEY_FILE)"
+            IMAGE_VERIFIED=1
+            break 2
+          elif [ $RESULT -eq 1 ]; then
+            echo "  key $KEY_FILE: registry authentication failed for all pull secrets"
+            AUTH_FAILED=1
+          else
+            echo "  key $KEY_FILE: signature invalid or other failure"
+          fi
+        done
+      done
+
+      if [ "$IMAGE_VERIFIED" -eq 0 ]; then
+        if [ "$AUTH_FAILED" -eq 1 ]; then
+          echo "✗ $IMAGE: registry authentication failed for all pull secrets and keys — check your imagePullSecrets"
+        else
+          echo "✗ $IMAGE: no configured key validated the signature"
+        fi
         FAILED=1
       fi
     done

--- a/templates/configmap-cosign-key.yaml
+++ b/templates/configmap-cosign-key.yaml
@@ -4,13 +4,23 @@ SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
 SPDX-License-Identifier: Apache-2.0
 */}}
 
-{{- if and (include "cosign.enabled" $) (eq .Values.imageVerification.publicKey.source "value") }}
+{{- if include "cosign.enabled" $ }}
+{{- $valueKeys := list -}}
+{{- range .Values.imageVerification.publicKeys -}}
+{{- if eq .source "value" -}}
+{{- $valueKeys = append $valueKeys . -}}
+{{- end -}}
+{{- end -}}
+{{- if $valueKeys }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-cosign-public-key
   labels: {{ include "app.labels.standard" $ | nindent 4 }}
 data:
-  cosign.pub: |
-    {{- .Values.imageVerification.publicKey.value | nindent 4 }}
+{{- range $i, $entry := $valueKeys }}
+  cosign.pub.{{ $i }}: |
+    {{- $entry.value | nindent 4 }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/templates/deployment.yml
+++ b/templates/deployment.yml
@@ -66,7 +66,7 @@ spec:
       securityContext: {{ .Values.podSecurityContext | toYaml | nindent 8 }}
 
 {{- if include "cosign.enabled" $ }}
-{{- include "cosign.validatePublicKey" $ }}
+{{- include "cosign.validatePublicKeys" $ }}
       initContainers:
 {{- include "cosign.initContainer" $ | nindent 6 }}
 {{- end }}
@@ -220,7 +220,8 @@ spec:
       {{- include "kong.jumper.volumes" $ | nindent 6 }}
       {{- include "kong.issuerService.volumes" $ | nindent 6 }}
 {{- if include "cosign.enabled" $ }}
-      {{- include "cosign.keyVolume" $ | nindent 6 }}
+      {{- include "cosign.keyVolumes" $ | nindent 6 }}
+      {{- include "cosign.dockerConfigVolume" $ | nindent 6 }}
       {{- include "cosign.pullSecretVolumes" $ | nindent 6 }}
 {{- end }}
       dnsPolicy: ClusterFirst

--- a/values.yaml
+++ b/values.yaml
@@ -1188,31 +1188,44 @@ imageVerification:
     repository: cosign
     tag: "v2.5.3"
 
-  # -- Public key configuration for signature verification
-  # Exactly ONE of the three sources must be configured: value, configMapRef, or secretRef
-  publicKey:
-    # -- Source type: "value" (inline), "configMap", or "secret"
-    source: secret
-
-    # -- Inline public key PEM (used when source: value)
-    # value: |
-    #   -----BEGIN PUBLIC KEY-----
-    #   MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE...
-    #   -----END PUBLIC KEY-----
-
-    # -- ConfigMap reference (used when source: configMap)
-    configMapRef:
-      # -- Name of the ConfigMap containing the public key
-      name: ""
-      # -- Key within the ConfigMap
-      key: "cosign.pub"
-
-    # -- Secret reference (used when source: secret)
-    secretRef:
-      # -- Name of the Secret containing the public key
-      name: "cosign-public-key"
-      # -- Key within the Secret
-      key: "cosign.pub"
+  # -- List of public keys for signature verification.
+  # Verification succeeds if ANY key in the list validates the signature (OR logic).
+  # This enables key rotation: include both old and new key during a transition period.
+  #
+  # Each entry must specify 'source' and the corresponding fields for that source:
+  #
+  #   source: value       — inline PEM in values.yaml; all value-source entries are
+  #                         stored in a single auto-created ConfigMap.
+  #   source: configMap   — public key is a data entry in an existing ConfigMap.
+  #   source: secret      — public key is a data entry in an existing Secret.
+  #
+  # Examples:
+  #
+  #   # Inline PEM
+  #   - source: value
+  #     value: |
+  #       -----BEGIN PUBLIC KEY-----
+  #       MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE...
+  #       -----END PUBLIC KEY-----
+  #
+  #   # From an existing ConfigMap
+  #   - source: configMap
+  #     configMapRef:
+  #       name: "my-cosign-keys"
+  #       key: "cosign.pub"
+  #
+  #   # From an existing Secret
+  #   - source: secret
+  #     secretRef:
+  #       name: "cosign-public-key"
+  #       key: "cosign.pub"
+  publicKeys:
+    - source: secret
+      secretRef:
+        # -- Name of the Secret containing the public key
+        name: "cosign-public-key"
+        # -- Key within the Secret
+        key: "cosign.pub"
 
   # -- Container security context for verification InitContainer
   containerSecurityContext:


### PR DESCRIPTION
## Summary

- Replaces `imageVerification.publicKey` (singular) with `imageVerification.publicKeys` (list); verification succeeds if **any** key validates the signature (OR semantics), enabling key rotation without downtime
- Supports all three source types (`value`, `configMap`, `secret`) in the same list; multiple inline `value` entries share a single auto-created ConfigMap
- Hardens the initContainer shell script with a range of bug fixes (see below)

## Breaking Change

`imageVerification.publicKey` is removed. See [UPGRADE.md](UPGRADE.md) for the migration guide (before/after examples included).

## Shell Script Fixes

| Severity | Fix |
|---|---|
| High | Registry extraction now correctly handles `host:port` registries and Docker Hub short-form images (`ubuntu:latest`) |
| High | Docker Hub credentials (`https://index.docker.io/v1/`) are now matched in pull secrets |
| Medium | `grep` fallback escapes registry dots to avoid BRE wildcard matches (e.g. `ghcr.io` no longer matches `ghcrXio`) |
| Medium | Auth grep pattern expanded to cover `403 Forbidden`, `access denied`, `authentication required` |
| Medium | All pull secrets are tried before giving up — no early abort on non-auth failures |
| Medium | `$hasValueSource` deduplication uses a `dict` to persist across Helm `range` loop iterations |
| Low | `cosign login` failures are surfaced as warnings instead of being silently ignored |
| Low | Image list parsed with `jq -r '.[]'` instead of fragile `tr`/`cut` |

## Helm Templating

All scenarios validated with `helm template`:
- Single / multiple `source: value` keys (deduplication verified)
- Mixed `source: value` + `source: configMap` + `source: secret`
- `imageVerification.enabled: false` produces no cosign artefacts
- Empty `publicKeys`, missing `configMapRef.key`, missing `secretRef.key` all fail at render time with clear indexed error messages