### PR TITLE
Feature/warmup component

### DIFF
--- a/README.md
+++ b/README.md
@@ -807,7 +807,7 @@ The following table provides a comprehensive list of all configurable parameters
 | jumper.enabled | bool | `true` | Enable Jumper container deployment |
 | jumper.environment | list | `[]` | Additional environment variables for Jumper container - {name: foo, value: bar} |
 | jumper.existingJwkSecretName | string | `nil` | Existing JWK secret name for OAuth token issuance (alternative to keyRotation.enabled=true) Must be compatible with gateway-rotator format: https://github.com/telekom/gateway-rotator#key-rotation-process |
-| jumper.image | object | `{"repository":"gateway-jumper","tag":"4.6.1"}` | Jumper image configuration (inherits from global.image) |
+| jumper.image | object | `{"repository":"gateway-jumper","tag":"4.8.0"}` | Jumper image configuration (inherits from global.image) |
 | jumper.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for Jumper container |
 | jumper.internetFacingZones | list | `[]` | List of zones that are considered internet-facing (empty list uses Jumper's default configuration) Example: [space, canis, aries] |
 | jumper.issuerUrl | string | `"https://<your-gateway-host>/auth/realms/default"` | Issuer service URL for gateway token issuance (your gateway's auth realm endpoint) |
@@ -819,6 +819,9 @@ The following table provides a comprehensive list of all configurable parameters
 | jumper.resources | object | `{"limits":{"cpu":"1500m","memory":"1Gi"},"requests":{"cpu":"1500m","memory":"1Gi"}}` | Jumper container resource limits and requests |
 | jumper.stargateUrl | string | `"https://<your-gateway-host>"` | Gateway URL for Gateway-to-Gateway communication |
 | jumper.startupProbe | object | `{"failureThreshold":285,"httpGet":{"path":"/actuator/health/readiness","port":"jumper","scheme":"HTTP"},"initialDelaySeconds":15,"periodSeconds":1}` | Jumper startup probe configuration |
+| jumper.warmup | object | `{"enabled":false,"urls":[]}` | Warmup configuration for cold start optimization |
+| jumper.warmup.enabled | bool | `false` | Enable warmup on startup (set to false to completely disable) |
+| jumper.warmup.urls | list | `[]` | List of URLs to warm up (DNS, TLS handshake, connection pool, LMS token generation) Example: [https://iris.2.2.2.2.nip.io, https://iris.3.3.3.3.nip.io] |
 | jumper.zoneHealth.databaseConnectionTimeout | int | `500` | Redis connection timeout in milliseconds |
 | jumper.zoneHealth.databaseHost | string | `"localhost"` | Redis database hostname |
 | jumper.zoneHealth.databaseIndex | int | `2` | Redis database index |

--- a/templates/_kong.tpl
+++ b/templates/_kong.tpl
@@ -507,6 +507,18 @@ false
 - name: JUMPER_INTERNET_FACING_ZONES
   value: {{ .Values.jumper.internetFacingZones | join "," | quote }}
 {{- end }}
+{{- if hasKey .Values.jumper "warmup" }}
+- name: JUMPER_WARMUP_ENABLED
+  value: {{ .Values.jumper.warmup.enabled | quote }}
+{{- if .Values.jumper.warmup.timeout }}
+- name: JUMPER_WARMUP_TIMEOUT
+  value: {{ .Values.jumper.warmup.timeout | quote }}
+{{- end }}
+{{- if not (empty .Values.jumper.warmup.urls) }}
+- name: JUMPER_WARMUP_URLS
+  value: {{ .Values.jumper.warmup.urls | join "," | quote }}
+{{- end }}
+{{- end }}
 - name: JAVA_TOOL_OPTIONS
   value: {{ .Values.jumper.jvmOpts }}
 - name: PUBLISH_EVENT_URL

--- a/templates/_kong.tpl
+++ b/templates/_kong.tpl
@@ -518,6 +518,10 @@ false
 - name: JUMPER_WARMUP_URLS
   value: {{ .Values.jumper.warmup.urls | join "," | quote }}
 {{- end }}
+{{- if .Values.jumper.warmup.enabled }}
+- name: MANAGEMENT_ENDPOINT_HEALTH_GROUP_READINESS_INCLUDE
+  value: "readinessState,warmup"
+{{- end }}
 {{- end }}
 - name: JAVA_TOOL_OPTIONS
   value: {{ .Values.jumper.jvmOpts }}

--- a/templates/_kong.tpl
+++ b/templates/_kong.tpl
@@ -514,6 +514,10 @@ false
 - name: JUMPER_WARMUP_TIMEOUT
   value: {{ .Values.jumper.warmup.timeout | quote }}
 {{- end }}
+{{- if .Values.jumper.warmup.iterations }}
+- name: JUMPER_WARMUP_ITERATIONS
+  value: {{ .Values.jumper.warmup.iterations | quote }}
+{{- end }}
 {{- if not (empty .Values.jumper.warmup.urls) }}
 - name: JUMPER_WARMUP_URLS
   value: {{ .Values.jumper.warmup.urls | join "," | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -826,7 +826,7 @@ jumper:
     # registry: ""  # Override global.image.registry
     # namespace: ""  # Override global.image.namespace
     repository: gateway-jumper
-    tag: "4.6.1"
+    tag: "4.8.0"
 
   # -- Image pull policy for Jumper container
   imagePullPolicy: IfNotPresent
@@ -914,6 +914,16 @@ jumper:
     databaseSecretKey: redis-password
     # -- Enable zone health monitoring
     enabled: false
+
+  # -- Warmup configuration for cold start optimization
+  warmup:
+    # -- Enable warmup on startup (set to false to completely disable)
+    enabled: false
+    # -- Maximum overall warmup duration (omit to use Jumper's built-in default of 15s)
+    #timeout: 15s
+    # -- List of URLs to warm up (DNS, TLS handshake, connection pool, LMS token generation)
+    # Example: [https://iris.2.2.2.2.nip.io, https://iris.3.3.3.3.nip.io]
+    urls: []
 
   # -- List of zones that are considered internet-facing (empty list uses Jumper's default configuration)
   # Example: [space, canis, aries]

--- a/values.yaml
+++ b/values.yaml
@@ -921,6 +921,8 @@ jumper:
     enabled: false
     # -- Maximum overall warmup duration (omit to use Jumper's built-in default of 15s)
     #timeout: 15s
+    # -- Number of iterations per URL for JIT warmup (omit to use Jumper's built-in default of 1)
+    #iterations:
     # -- List of URLs to warm up (DNS, TLS handshake, connection pool, LMS token generation)
     # Example: [https://iris.2.2.2.2.nip.io, https://iris.3.3.3.3.nip.io]
     urls: []


### PR DESCRIPTION
Adds Helm chart values and environment variable wiring to configure the new Jumper warmup component introduced in [gateway-jumper#111](https://github.com/telekom/gateway-jumper/pull/111). This allows per-environment control of warmup behavior through standard Helm value overrides.

**Warmup Values & Environment Variables (feat)**

- Add jumper.warmup block to values.yaml:
  - enabled — toggle warmup on/off (default: false)
  - timeout — warmup timeout
  - domains — list of domains to warm up
  - iterations — number of warmup passes per domain
- Wire the following env vars in _kong.tpl Jumper env template:

**Readiness Group Override (chore)**

- When warmup is enabled, override the Spring Boot readiness health group to include the warmup health indicator, ensuring the pod stays NotReady until warmup completes