### PR TITLE
feat: add nginxProxyBufferSize and nginxProxyBuffers chart values

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,48 @@ You can tune Kong's asynchronous route refresh behavior with these variables:
 [db_update_propagation]: https://docs.konghq.com/gateway/2.8.x/reference/configuration/#db_update_propagation
 [worker_state_update_frequency]: https://docs.konghq.com/gateway/2.8.x/reference/configuration/#worker_state_update_frequency
 
+### Nginx Proxy Buffer Tuning
+
+If upstream services return large response headers (e.g. verbose `Set-Cookie`, `Authorization`, or custom headers), Kong/Nginx may return **502 Bad Gateway** with:
+
+```
+upstream sent too big header while reading response header from upstream
+```
+
+This is caused by Nginx's `proxy_buffer_size` being too small for the response headers. The default is **4k** (or 8k on 64-bit platforms).
+
+> **Note:** This is different from `nginxLargeClientBuffers` (`large_client_header_buffers`), which controls buffers for **incoming request** headers from clients. The `proxy_buffer_size` directive controls the buffer for **response** headers from upstream backends.
+
+**Configuration:**
+
+| Helm Value | Kong Env Var | Nginx Directive | Purpose |
+|---|---|---|---|
+| `nginxProxyBufferSize` | `KONG_NGINX_PROXY_PROXY_BUFFER_SIZE` | `proxy_buffer_size` | Buffer for upstream response headers |
+| `nginxProxyBuffers` | `KONG_NGINX_PROXY_PROXY_BUFFERS` | `proxy_buffers` | Number and size of buffers for response body |
+| `nginxProxyBusyBuffersSize` | `KONG_NGINX_PROXY_PROXY_BUSY_BUFFERS_SIZE` | `proxy_busy_buffers_size` | Max size of busy buffers (auto-derived if not set) |
+
+**Recommended configuration:**
+
+When increasing `proxy_buffer_size`, you **must** also increase `proxy_buffers` so that the total buffer size satisfies Nginx's constraint: `proxy_busy_buffers_size` (defaults to `2 × proxy_buffer_size`) must be less than the total `proxy_buffers` size minus one buffer.
+
+```yaml
+# Fix for "upstream sent too big header" 502 errors
+nginxProxyBufferSize: "16k"
+nginxProxyBuffers: "8 16k"
+# nginxProxyBusyBuffersSize is optional — defaults to 2 × proxy_buffer_size (32k),
+# which is satisfied when proxy_buffers total (8 × 16k = 128k) > 32k.
+```
+
+**Value format:**
+- `nginxProxyBufferSize` takes a single size: `"16k"`, `"32k"`
+- `nginxProxyBuffers` takes `<count> <size>`: `"8 16k"` means 8 buffers of 16 KiB each
+- `nginxProxyBusyBuffersSize` takes a single size: `"32k"`
+
+**References:**
+- [Nginx proxy_buffer_size](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size)
+- [Nginx proxy_buffers](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers)
+- [Kong: Injecting Nginx directives](https://docs.konghq.com/gateway/latest/reference/configuration/#injecting-individual-nginx-directives)
+
 ### Relabeling application metrics
 
 In case you need to manipulate existing application metrcis or add new ones,
@@ -966,6 +1008,27 @@ The following table provides a comprehensive list of all configurable parameters
 ## Troubleshooting
 
 If the Gateway deployment fails to start, check the container logs for error messages.
+
+### Proxy Buffer Size Error
+
+**Symptom:**
+
+```
+nginx: [emerg] "proxy_busy_buffers_size" must be less than the size of all "proxy_buffers" minus one buffer
+nginx: configuration file /kong/nginx.conf test failed
+```
+
+**Solution:**
+This error occurs when `nginxProxyBufferSize` is set without also increasing `nginxProxyBuffers`. The default `proxy_buffers` (`8 4k` = 32k total) is too small to satisfy the constraint when `proxy_buffer_size` is increased.
+
+Set both values together:
+
+```yaml
+nginxProxyBufferSize: "16k"
+nginxProxyBuffers: "8 16k"
+```
+
+See [Nginx Proxy Buffer Tuning](#nginx-proxy-buffer-tuning) for details.
 
 ### SSL Verification Error
 

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -585,6 +585,48 @@ You can tune Kong's asynchronous route refresh behavior with these variables:
 [db_update_propagation]: https://docs.konghq.com/gateway/2.8.x/reference/configuration/#db_update_propagation
 [worker_state_update_frequency]: https://docs.konghq.com/gateway/2.8.x/reference/configuration/#worker_state_update_frequency
 
+### Nginx Proxy Buffer Tuning
+
+If upstream services return large response headers (e.g. verbose `Set-Cookie`, `Authorization`, or custom headers), Kong/Nginx may return **502 Bad Gateway** with:
+
+```
+upstream sent too big header while reading response header from upstream
+```
+
+This is caused by Nginx's `proxy_buffer_size` being too small for the response headers. The default is **4k** (or 8k on 64-bit platforms).
+
+> **Note:** This is different from `nginxLargeClientBuffers` (`large_client_header_buffers`), which controls buffers for **incoming request** headers from clients. The `proxy_buffer_size` directive controls the buffer for **response** headers from upstream backends.
+
+**Configuration:**
+
+| Helm Value | Kong Env Var | Nginx Directive | Purpose |
+|---|---|---|---|
+| `nginxProxyBufferSize` | `KONG_NGINX_PROXY_PROXY_BUFFER_SIZE` | `proxy_buffer_size` | Buffer for upstream response headers |
+| `nginxProxyBuffers` | `KONG_NGINX_PROXY_PROXY_BUFFERS` | `proxy_buffers` | Number and size of buffers for response body |
+| `nginxProxyBusyBuffersSize` | `KONG_NGINX_PROXY_PROXY_BUSY_BUFFERS_SIZE` | `proxy_busy_buffers_size` | Max size of busy buffers (auto-derived if not set) |
+
+**Recommended configuration:**
+
+When increasing `proxy_buffer_size`, you **must** also increase `proxy_buffers` so that the total buffer size satisfies Nginx's constraint: `proxy_busy_buffers_size` (defaults to `2 × proxy_buffer_size`) must be less than the total `proxy_buffers` size minus one buffer.
+
+```yaml
+# Fix for "upstream sent too big header" 502 errors
+nginxProxyBufferSize: "16k"
+nginxProxyBuffers: "8 16k"
+# nginxProxyBusyBuffersSize is optional — defaults to 2 × proxy_buffer_size (32k),
+# which is satisfied when proxy_buffers total (8 × 16k = 128k) > 32k.
+```
+
+**Value format:**
+- `nginxProxyBufferSize` takes a single size: `"16k"`, `"32k"`
+- `nginxProxyBuffers` takes `<count> <size>`: `"8 16k"` means 8 buffers of 16 KiB each
+- `nginxProxyBusyBuffersSize` takes a single size: `"32k"`
+
+**References:**
+- [Nginx proxy_buffer_size](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size)
+- [Nginx proxy_buffers](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers)
+- [Kong: Injecting Nginx directives](https://docs.konghq.com/gateway/latest/reference/configuration/#injecting-individual-nginx-directives)
+
 ### Relabeling application metrics
 
 In case you need to manipulate existing application metrcis or add new ones,
@@ -683,6 +725,27 @@ The following table provides a comprehensive list of all configurable parameters
 ## Troubleshooting
 
 If the Gateway deployment fails to start, check the container logs for error messages.
+
+### Proxy Buffer Size Error
+
+**Symptom:**
+
+```
+nginx: [emerg] "proxy_busy_buffers_size" must be less than the size of all "proxy_buffers" minus one buffer
+nginx: configuration file /kong/nginx.conf test failed
+```
+
+**Solution:**
+This error occurs when `nginxProxyBufferSize` is set without also increasing `nginxProxyBuffers`. The default `proxy_buffers` (`8 4k` = 32k total) is too small to satisfy the constraint when `proxy_buffer_size` is increased.
+
+Set both values together:
+
+```yaml
+nginxProxyBufferSize: "16k"
+nginxProxyBuffers: "8 16k"
+```
+
+See [Nginx Proxy Buffer Tuning](#nginx-proxy-buffer-tuning) for details.
 
 ### SSL Verification Error
 

--- a/templates/_kong.tpl
+++ b/templates/_kong.tpl
@@ -269,6 +269,18 @@ false
 - name: KONG_NGINX_PROXY_LARGE_CLIENT_HEADER_BUFFERS
   value: '{{ .Values.nginxLargeClientBuffers }}'
 {{- end -}}
+{{- if .Values.nginxProxyBufferSize }}
+- name: KONG_NGINX_PROXY_PROXY_BUFFER_SIZE
+  value: '{{ .Values.nginxProxyBufferSize }}'
+{{- end -}}
+{{- if .Values.nginxProxyBuffers }}
+- name: KONG_NGINX_PROXY_PROXY_BUFFERS
+  value: '{{ .Values.nginxProxyBuffers }}'
+{{- end -}}
+{{- if .Values.nginxProxyBusyBuffersSize }}
+- name: KONG_NGINX_PROXY_PROXY_BUSY_BUFFERS_SIZE
+  value: '{{ .Values.nginxProxyBusyBuffersSize }}'
+{{- end -}}
 {{- if .Values.defaultTlsSecret }}
 - name: KONG_SSL_CERT
   value: /opt/kong/default-https/tls.crt

--- a/values.yaml
+++ b/values.yaml
@@ -264,6 +264,18 @@ nginxWorkerProcesses: 4
 nginxHttpLuaSharedDict: "prometheus_metrics 15m"
 # -- Nginx large client header buffers configuration
 #nginxLargeClientBuffers: "8 16k"
+# -- Nginx proxy buffer size for upstream response headers (e.g. "16k", "32k").
+#    Fixes "upstream sent too big header" 502 errors.
+#    NOTE: When increasing this, you must also set nginxProxyBuffers so that
+#    the total proxy_buffers size exceeds 2 * proxy_buffer_size. Otherwise Nginx
+#    will fail to start with a proxy_busy_buffers_size constraint error.
+#nginxProxyBufferSize: "16k"
+# -- Nginx proxy buffers count and size for upstream response body (e.g. "8 16k").
+#    Must be set when nginxProxyBufferSize is increased beyond the default buffer size (4k/8k).
+#nginxProxyBuffers: "8 16k"
+# -- Nginx proxy busy buffers size (defaults to 2 * proxy_buffer_size if not set).
+#    Only needed if you want to override the automatic default.
+#nginxProxyBusyBuffersSize: "32k"
 # -- Kong worker consistency mode (eventual or strict)
 workerConsistency: eventual
 # -- Frequency in seconds to poll for worker state updates


### PR DESCRIPTION
Expose proxy_buffer_size and proxy_buffers Nginx directives via KONG_NGINX_PROXY_PROXY_BUFFER_SIZE and KONG_NGINX_PROXY_PROXY_BUFFERS environment variables. This fixes 502 errors caused by large upstream response headers exceeding the default 4k proxy_buffer_size.