### PR TITLE
feat(affinity)!: replace podAntiAffinity toggle with overridable affinity value

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,11 +502,41 @@ For detailed configuration, examples, and troubleshooting, see the [Argo Rollout
 - [Argo Rollouts Canary Strategy](https://argoproj.github.io/rollouts/features/canary/)
 - [Argo Rollouts Analysis](https://argoproj.github.io/rollouts/features/analysis/)
 
-### Pod Anti-Affinity and Topology Key
+### Pod Anti-Affinity
 
-Distribute pods across multiple nodes for high availability. If one node fails, pods on other nodes continue serving traffic.
+Distribute pods across failure domains (nodes, availability zones, ...) for high
+availability. If one domain fails, pods in other domains continue serving traffic.
 
-Configure pod distribution using the `topologyKey` setting. See the [Parameters](#parameters) section for configuration options and the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity) for details on pod anti-affinity.
+Pod scheduling is configured through the single `affinity` value, which is passed
+straight into the pod spec's `affinity` field (rendered through `tpl`, so it may
+contain template expressions such as `{{ .Release.Name }}`). The chart
+default **requires** pods of the same instance to be spread across nodes
+(one per node), and additionally **prefers** spreading them across availability
+zones:
+
+```yaml
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: "{{ .Release.Name }}-kong"
+        topologyKey: kubernetes.io/hostname
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/instance: "{{ .Release.Name }}-kong"
+          topologyKey: topology.kubernetes.io/zone
+```
+
+> **Note:** the required per-node rule means a deployment cannot run more replicas
+> than it has schedulable nodes — excess pods stay `Pending`. Override `affinity`
+> (e.g. switch the node rule to `preferred`) if you run more replicas than nodes.
+
+Override the whole `affinity` object to define custom (anti-)affinity rules.
+See the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity) for details on pod affinity and anti-affinity.
 
 ### Automatic Certificate and Key Rotation
 
@@ -698,6 +728,7 @@ The following table provides a comprehensive list of all configurable parameters
 | adminApi.ingress.hosts | list | `[{"host":"chart-example.local","paths":[{"path":"/","pathType":"Prefix"}]}]` | Ingress hosts configuration |
 | adminApi.ingress.tls | list | `[]` |  |
 | adminApi.tls.enabled | bool | `false` | Enable HTTPS for Admin API |
+| affinity | object | `{"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"podAffinityTerm":{"labelSelector":{"matchLabels":{"app.kubernetes.io/instance":"{{ .Release.Name }}-kong"}},"topologyKey":"topology.kubernetes.io/zone"},"weight":100}],"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"app.kubernetes.io/instance":"{{ .Release.Name }}-kong"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity rules for the gateway pods. Rendered through `tpl`, so values may embed template expressions (e.g. `{{ .Release.Name }}`). Override this whole object per-environment to apply custom or multiple (anti-)affinity rules. Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity |
 | argoRollouts.analysisTemplates.enabled | bool | `true` | Enable creation of AnalysisTemplates |
 | argoRollouts.analysisTemplates.errorRate.authentication | object | `{"basicKey":"basic-auth","enabled":true,"secretName":"victoria-metrics-secret"}` | Prometheus Basic Auth authentication configuration |
 | argoRollouts.analysisTemplates.errorRate.authentication.basicKey | string | `"basic-auth"` | Secret key for base64 encoded user:password Basic Auth header |
@@ -772,7 +803,6 @@ The following table provides a comprehensive list of all configurable parameters
 | global.passwordRules.enabled | bool | `false` | Enable password rule enforcement |
 | global.passwordRules.length | int | `12` | Minimum password length |
 | global.passwordRules.mustMatch | list | `["[a-z]","[A-Z]","[0-9]","[^a-zA-Z0-9]"]` | Password must match these regex patterns |
-| global.podAntiAffinity.required | bool | `false` | Use required (hard) or preferred (soft) pod anti-affinity |
 | global.preStopSleepBase | int | `15` | Base sleep duration in seconds for pre-stop lifecycle hook |
 | global.tracing.collectorUrl | string | `"http://guardians-drax-collector.skoll:9411/api/v2/spans"` | Trace collector URL, used VERBATIM by both Kong and Jumper (no path is appended or stripped by the chart). Provide the FULL endpoint URL matching the selected `exporter`:   * exporter=zipkin -> full Zipkin v2 spans endpoint INCLUDING the path,       e.g. "http://collector:9411/api/v2/spans"   * exporter=otlp   -> full OTLP/HTTP traces endpoint INCLUDING the path,       e.g. "http://collector:4318/v1/traces" The same URL is applied to every target:   * Kong   + zipkin -> plugin `http_endpoint`   * Kong   + otlp   -> plugin `traces_endpoint`   * Jumper + zipkin -> TRACING_URL (Spring Boot zipkin endpoint)   * Jumper + otlp   -> TRACING_URL (Spring Boot otlp endpoint) Must include the http(s) scheme. IMPORTANT: when you switch `exporter`, update this URL to the target collector's protocol port AND path (Zipkin and OTLP usually listen on different ports/paths, e.g. 9411/api/v2/spans vs 4318/v1/traces). |
 | global.tracing.defaultServiceName | string | `"stargate"` | Service name displayed in tracing UI |
@@ -971,7 +1001,6 @@ The following table provides a comprehensive list of all configurable parameters
 | startupProbe | object | `{"failureThreshold":295,"httpGet":{"path":"/status","port":"status","scheme":"HTTP"},"initialDelaySeconds":5,"periodSeconds":1,"timeoutSeconds":1}` | Kong startup probe configuration |
 | strategy | object | `{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"}` | Deployment strategy configuration |
 | templateChangeTriggers | list | `[]` | List of template files for which a checksum annotation will be created |
-| topologyKey | string | `"kubernetes.io/hostname"` | Topology key for pod anti-affinity (spread pods across zones for high availability) |
 | workerConsistency | string | `"eventual"` | Kong worker consistency mode (eventual or strict) |
 | workerStateUpdateFrequency | int | `10` | Frequency in seconds to poll for worker state updates |
 

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -502,11 +502,41 @@ For detailed configuration, examples, and troubleshooting, see the [Argo Rollout
 - [Argo Rollouts Canary Strategy](https://argoproj.github.io/rollouts/features/canary/)
 - [Argo Rollouts Analysis](https://argoproj.github.io/rollouts/features/analysis/)
 
-### Pod Anti-Affinity and Topology Key
+### Pod Anti-Affinity
 
-Distribute pods across multiple nodes for high availability. If one node fails, pods on other nodes continue serving traffic.
+Distribute pods across failure domains (nodes, availability zones, ...) for high
+availability. If one domain fails, pods in other domains continue serving traffic.
 
-Configure pod distribution using the `topologyKey` setting. See the [Parameters](#parameters) section for configuration options and the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity) for details on pod anti-affinity.
+Pod scheduling is configured through the single `affinity` value, which is passed
+straight into the pod spec's `affinity` field (rendered through `tpl`, so it may
+contain template expressions such as `{{ "{{ .Release.Name }}" }}`). The chart
+default **requires** pods of the same instance to be spread across nodes
+(one per node), and additionally **prefers** spreading them across availability
+zones:
+
+```yaml
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: "{{ "{{ .Release.Name }}" }}-kong"
+        topologyKey: kubernetes.io/hostname
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/instance: "{{ "{{ .Release.Name }}" }}-kong"
+          topologyKey: topology.kubernetes.io/zone
+```
+
+> **Note:** the required per-node rule means a deployment cannot run more replicas
+> than it has schedulable nodes — excess pods stay `Pending`. Override `affinity`
+> (e.g. switch the node rule to `preferred`) if you run more replicas than nodes.
+
+Override the whole `affinity` object to define custom (anti-)affinity rules.
+See the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity) for details on pod affinity and anti-affinity.
 
 ### Automatic Certificate and Key Rotation
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -169,6 +169,59 @@ image:
   tag: "2.0.0"
 ```
 
+### `global.podAntiAffinity` and `topologyKey` replaced by `affinity` (BREAKING)
+
+The bespoke `global.podAntiAffinity.required` toggle and the top-level
+`topologyKey` value have been removed. Pod scheduling is now configured through a
+single top-level `affinity` value that is passed straight into the pod spec's
+`affinity` field. This allows arbitrary affinity/anti-affinity rules, including
+spreading across multiple topology domains at once.
+
+The value is rendered through `tpl`, so it may contain template expressions
+(e.g. to reference the release name in label selectors).
+
+**Before:**
+```yaml
+global:
+  podAntiAffinity:
+    required: true   # hard per-node anti-affinity
+topologyKey: kubernetes.io/hostname
+```
+
+**After (equivalent hard per-node rule):**
+```yaml
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: "{{ .Release.Name }}-kong"
+        topologyKey: kubernetes.io/hostname
+```
+
+The chart default now **requires** pods of the same instance to be spread across
+nodes (one per node) and additionally **prefers** spreading across availability
+zones:
+```yaml
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: "{{ .Release.Name }}-kong"
+        topologyKey: kubernetes.io/hostname
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/instance: "{{ .Release.Name }}-kong"
+          topologyKey: topology.kubernetes.io/zone
+```
+Note: the required per-node rule means the number of replicas cannot exceed the
+number of schedulable nodes; override `affinity` if you need more replicas than
+nodes.
+
 ### Platform Configuration Removal (BREAKING)
 
 The platform-specific configuration mechanism has been removed. Platform-specific values are now integrated as explicit defaults in `values.yaml`.

--- a/templates/deployment.yml
+++ b/templates/deployment.yml
@@ -48,20 +48,8 @@ spec:
         {{- include "app.labels.standard" $ | nindent 8 }}
     spec:
       {{- include "image_pull_secrets" $ | indent 6 }}
-      affinity:
-        podAntiAffinity:
-{{- if eq .Values.global.podAntiAffinity.required true }}
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels: {{ include "app.labels.selectorLabels" $ | nindent 16 }}
-            topologyKey: {{ .Values.topologyKey }}
-{{- else }}
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchLabels: {{ include "app.labels.selectorLabels" $ | nindent 20 }}
-                topologyKey: {{ .Values.topologyKey }}
+{{- with .Values.affinity }}
+      affinity: {{ tpl (toYaml .) $ | nindent 8 }}
 {{- end }}
       securityContext: {{ .Values.podSecurityContext | toYaml | nindent 8 }}
 

--- a/values.yaml
+++ b/values.yaml
@@ -95,10 +95,6 @@ global:
     # -- Sample ratio for requests without trace IDs (0=off, 1=all requests)
     sampleRatio: 1
 
-  podAntiAffinity:
-    # -- Use required (hard) or preferred (soft) pod anti-affinity
-    required: false
-
   # -- Fail template rendering on unset required values
   failOnUnsetValues: true
 
@@ -260,8 +256,26 @@ containerSecurityContext:
     drop:
       - ALL
 
-# -- Topology key for pod anti-affinity (spread pods across zones for high availability)
-topologyKey: kubernetes.io/hostname
+# -- Affinity rules for the gateway pods. Rendered through `tpl`, so values may
+# embed template expressions (e.g. `{{ .Release.Name }}`). Override this whole
+# object per-environment to apply custom or multiple (anti-)affinity rules.
+# Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+affinity:
+  podAntiAffinity:
+    # Require pods of this instance to be spread across nodes (one per node)
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: "{{ .Release.Name }}-kong"
+        topologyKey: kubernetes.io/hostname
+    # Prefer also spreading across availability zones (mitigates AZ imbalance)
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/instance: "{{ .Release.Name }}-kong"
+          topologyKey: topology.kubernetes.io/zone
 
 # Job security configuration
 jobs:


### PR DESCRIPTION
## Summary

Replaces the bespoke pod anti-affinity config (`global.podAntiAffinity.required` + `topologyKey`) with a single, overridable `affinity` value passed straight into the pod spec. Operators can now express arbitrary or multiple (anti-)affinity rules without patching the chart.

## Default behavior

Soft anti-affinity that spreads across nodes (weight 100), then availability zones (weight 50). Best-effort, so it never blocks scheduling.

## Breaking change

`global.podAntiAffinity.required` and `topologyKey` are removed. Configs setting either must migrate to `affinity` — see `UPGRADE.md`.

```yaml
# Before
global: { podAntiAffinity: { required: true } }
topologyKey: kubernetes.io/hostname

# After (equivalent hard per-node rule)
affinity:
  podAntiAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
      - labelSelector:
          matchLabels:
            app.kubernetes.io/instance: "{{ .Release.Name }}-kong"
        topologyKey: kubernetes.io/hostname
```

The value is rendered through `tpl`, so it may embed template expressions.

## Testing

`helm lint` passes; `helm template` verified for defaults + overrides; `helm-docs` regenerated.
