### PR TITLE
feat: add environment variable support for Kong container

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,6 +746,7 @@ The following table provides a comprehensive list of all configurable parameters
 | disableUpstreamCache | bool | `false` | Disable upstream response caching |
 | dns.dnsConfig | object | `{}` | Custom DNS configuration for the pod. Passed through directly to PodSpec.dnsConfig. Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config |
 | dns.dnsPolicy | string | `"ClusterFirst"` | DNS policy for the pod. Defaults to ClusterFirst. Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy |
+| environment | list | `[]` | Additional environment variables for Kong container - {name: foo, value: bar} |
 | externalDatabase.ssl | bool | `true` | Enable SSL for external database connections |
 | externalDatabase.sslVerify | bool | `false` | Verify SSL certificates for external database |
 | global.database.database | string | `"kong"` | Database name |

--- a/templates/deployment.yml
+++ b/templates/deployment.yml
@@ -165,6 +165,9 @@ spec:
         {{- include "kong.nginx.directives" $ | indent 8 }}
         {{- include "kong.customPlugins.env" $ | indent 8 }}
         {{- include "kong.env" $ | indent 8 }}
+        {{- with .Values.environment }}
+        {{- . | toYaml | nindent 8 }}
+        {{- end }}
         command: [ "/bin/sh", "-c", "KONG_NGINX_DAEMON='off' kong start" ]
         resources: {{ .Values.resources | toYaml | nindent 10 }}
         lifecycle:

--- a/values.yaml
+++ b/values.yaml
@@ -114,6 +114,10 @@ image:
 # -- Image pull policy for Kong container
 imagePullPolicy: IfNotPresent
 
+# -- Additional environment variables for Kong container
+#- {name: foo, value: bar}
+environment: []
+
 # Migration behavior: 'bootstrap' (new deployment), 'upgrade' (Kong version upgrade), 'jobs' (ENI plugin migration), or 'none'
 # -- Migration mode for database initialization or upgrades
 migrations: none


### PR DESCRIPTION
Add environment key at root level in values.yaml to allow passing custom environment variables to the Kong container, following the same pattern as jumper.environment and issuerService.environment.