### PR TITLE
feat: migrate default image references to Artifactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,14 +92,14 @@ Images are configured using a cascading defaults system with global and componen
 ```yaml
 global:
   image:
-    registry: mtr.devops.telekom.de
-    namespace: eu_it_co_development/o28m
+    registry: artifactory.devops.telekom.de
+    namespace: mcicd-internal-oci/tardis/components/gateway
 
 image:
   # registry: ""       # Optional: Override global.image.registry
   # namespace: ""      # Optional: Override global.image.namespace
-  repository: gateway-kong
-  tag: "1.1.0"
+  repository: kong
+  tag: "1.7.0"
 ```
 
 Images are constructed as: `{registry}/{namespace}/{repository}:{tag}`
@@ -742,7 +742,7 @@ The following table provides a comprehensive list of all configurable parameters
 | circuitbreaker.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000}` | Container security context for circuit breaker |
 | circuitbreaker.count | int | `4` | Failure count threshold for circuit breaker activation |
 | circuitbreaker.enabled | bool | `false` | Enable circuit breaker component deployment |
-| circuitbreaker.image | object | `{"repository":"gateway-circuitbreaker","tag":"2.1.0"}` | Circuit breaker image configuration (inherits from global.image) |
+| circuitbreaker.image | object | `{"repository":"circuitbreaker-service","tag":"2.1.0"}` | Circuit breaker image configuration (inherits from global.image) |
 | circuitbreaker.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for circuit breaker container |
 | circuitbreaker.interval | string | `"60s"` | Check interval for circuit breaker |
 | circuitbreaker.resources | object | `{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"50m","memory":"200Mi"}}` | Circuit breaker container resource limits and requests |
@@ -763,8 +763,8 @@ The following table provides a comprehensive list of all configurable parameters
 | global.database.username | string | `"kong"` | Database username |
 | global.environment | string | `"default"` | Environment name (e.g. playground, preprod, ...) |
 | global.failOnUnsetValues | bool | `true` | Fail template rendering on unset required values |
-| global.image.namespace | string | `"eu_it_co_development/o28m"` | Default image namespace |
-| global.image.registry | string | `"mtr.devops.telekom.de"` | Default image registry |
+| global.image.namespace | string | `"mcicd-internal-oci/tardis/components/gateway"` | Default image namespace |
+| global.image.registry | string | `"artifactory.devops.telekom.de"` | Default image registry |
 | global.imagePullPolicy | string | `"IfNotPresent"` | Default image pull policy |
 | global.imagePullSecrets | list | `[]` | Array of pull secret names for image pulling |
 | global.ingress.annotations | object | `{}` | Common annotations for all ingress resources (can be extended per component) |
@@ -783,12 +783,12 @@ The following table provides a comprehensive list of all configurable parameters
 | hpaAutoscaling.cpuUtilizationPercentage | int | `80` | Target CPU utilization percentage |
 | hpaAutoscaling.maxReplicas | int | `10` | Maximum number of replicas |
 | hpaAutoscaling.minReplicas | int | `3` | Minimum number of replicas |
-| image | object | `{"repository":"gateway-kong","tag":"1.7.1"}` | Kong Gateway image configuration (inherits from global.image) |
+| image | object | `{"repository":"kong","tag":"1.7.1"}` | Kong Gateway image configuration (inherits from global.image) |
 | image.tag | string | `"1.7.1"` | Kong Gateway image tag |
 | imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for Kong container |
 | imageVerification.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000}` | Container security context for verification InitContainer |
 | imageVerification.enabled | bool | `false` | Enable cosign image signature verification (disable if using Kyverno policy) |
-| imageVerification.image | object | `{"repository":"cosign","tag":"v2.5.3"}` | Cosign image configuration (inherits from global.image) |
+| imageVerification.image | object | `{"namespace":"mcicd-internal-oci/tardis/infra/components/ghcr.io.docker/sigstore/cosign","repository":"cosign","tag":"v2.5.3"}` | Cosign image configuration (does not inherit global.image namespace) |
 | imageVerification.mode | string | `"enforce"` | Verification mode: "enforce" (block pod on invalid signature) or "audit" (log and continue) |
 | imageVerification.publicKey | object | `{"configMapRef":{"key":"cosign.pub","name":""},"secretRef":{"key":"cosign.pub","name":"cosign-public-key"},"source":"secret"}` | Public key configuration for signature verification Exactly ONE of the three sources must be configured: value, configMapRef, or secretRef |
 | imageVerification.publicKey.configMapRef | object | `{"key":"cosign.pub","name":""}` | ConfigMap reference (used when source: configMap) |
@@ -803,19 +803,19 @@ The following table provides a comprehensive list of all configurable parameters
 | issuerService.enabled | bool | `true` | Enable Issuer Service container deployment |
 | issuerService.environment | list | `[]` | Additional environment variables for Issuer Service container - {name: foo, value: bar} |
 | issuerService.existingJwkSecretName | string | `nil` | Existing JWK secret name for OAuth token signing (alternative to keyRotation.enabled=true) Must be compatible with gateway-rotator format: https://github.com/telekom/gateway-rotator#key-rotation-process |
-| issuerService.image | object | `{"repository":"gateway-issuer-service-go","tag":"2.3.4"}` | Issuer Service image configuration (inherits from global.image) |
+| issuerService.image | object | `{"repository":"issuer-service","tag":"2.3.4"}` | Issuer Service image configuration (inherits from global.image) |
 | issuerService.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for Issuer Service container |
 | issuerService.livenessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/health","port":"issuer-service","scheme":"HTTP"},"timeoutSeconds":5}` | Issuer Service liveness probe configuration |
 | issuerService.readinessProbe | object | `{"httpGet":{"path":"/health","port":"issuer-service","scheme":"HTTP"}}` | Issuer Service readiness probe configuration |
 | issuerService.resources | object | `{"limits":{"cpu":"50m","memory":"50Mi"},"requests":{"cpu":"50m","memory":"50Mi"}}` | Issuer Service container resource limits and requests |
 | issuerService.startupProbe | object | `{"failureThreshold":60,"httpGet":{"path":"/health","port":"issuer-service","scheme":"HTTP"},"periodSeconds":1}` | Issuer Service startup probe configuration |
-| job | object | `{"image":{"repository":"bash-curl","tag":"8.13.0"}}` | Job image configuration for setup jobs (inherits from global.image) |
+| job | object | `{"image":{"namespace":"mcicd-internal-oci/tardis/infra/components/helper","repository":"curl","tag":"8.17.0-r1"}}` | Job image configuration for setup jobs (curl helper image, does not inherit global.image namespace) |
 | jobs.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context for setup jobs |
 | jumper.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000}` | Container security context for Jumper |
 | jumper.enabled | bool | `true` | Enable Jumper container deployment |
 | jumper.environment | list | `[]` | Additional environment variables for Jumper container - {name: foo, value: bar} |
 | jumper.existingJwkSecretName | string | `nil` | Existing JWK secret name for OAuth token issuance (alternative to keyRotation.enabled=true) Must be compatible with gateway-rotator format: https://github.com/telekom/gateway-rotator#key-rotation-process |
-| jumper.image | object | `{"repository":"gateway-jumper","tag":"4.12.0"}` | Jumper image configuration (inherits from global.image) |
+| jumper.image | object | `{"repository":"jumper","tag":"4.12.0"}` | Jumper image configuration (inherits from global.image) |
 | jumper.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for Jumper container |
 | jumper.internetFacingZones | list | `[]` | List of zones that are considered internet-facing (empty list uses Jumper's default configuration) Example: [space, canis, aries] |
 | jumper.issuerUrl | string | `"https://<your-gateway-host>/auth/realms/default"` | Issuer service URL for gateway token issuance (your gateway's auth realm endpoint) |
@@ -936,7 +936,7 @@ The following table provides a comprehensive list of all configurable parameters
 | podSecurityContext | object | `{"fsGroup":1000,"runAsGroup":1000,"runAsUser":100,"seccompProfile":{"type":"RuntimeDefault"},"supplementalGroups":[1000]}` | Pod security context for Kong deployment (hardened defaults) |
 | postgresql.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsGroup":999,"runAsNonRoot":true,"runAsUser":999}` | Container security context for PostgreSQL |
 | postgresql.deployment | object | `{"annotations":{}}` | Additional deployment annotations |
-| postgresql.image | object | `{"repository":"postgresql","tag":"16.5"}` | PostgreSQL image configuration (inherits from global.image) |
+| postgresql.image | object | `{"namespace":"hub.docker.com","repository":"postgres","tag":"16-alpine"}` | PostgreSQL image configuration (Artifactory hub.docker.com remote repo, does not inherit global.image.namespace; registry is inherited since it's the same Artifactory host) |
 | postgresql.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for PostgreSQL container |
 | postgresql.maxConnections | string | `"100"` | Maximum number of client connections |
 | postgresql.maxPreparedTransactions | string | `"0"` | Maximum prepared transactions (0 disables prepared transactions) |

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -92,14 +92,14 @@ Images are configured using a cascading defaults system with global and componen
 ```yaml
 global:
   image:
-    registry: mtr.devops.telekom.de
-    namespace: eu_it_co_development/o28m
+    registry: artifactory.devops.telekom.de
+    namespace: mcicd-internal-oci/tardis/components/gateway
 
 image:
   # registry: ""       # Optional: Override global.image.registry
   # namespace: ""      # Optional: Override global.image.namespace
-  repository: gateway-kong
-  tag: "1.1.0"
+  repository: kong
+  tag: "1.7.0"
 ```
 
 Images are constructed as: `{registry}/{namespace}/{repository}:{tag}`

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,7 +8,71 @@ SPDX-License-Identifier: CC0-1.0
 
 This document provides guidance for upgrading between versions of the Gateway Helm chart.
 
+## Default Image Registry Changed to Artifactory (9.11.0 and up)
+
+### New Default Image Registry
+
+The chart's default `global.image.registry`/`namespace` were repointed from the Magenta Trusted Registry (MTR),
+which is being retired, to the Artifactory/JFrog Platform mirror:
+
+```yaml
+# Before
+global:
+  image:
+    registry: mtr.devops.telekom.de
+    namespace: eu_it_co_development/o28m
+
+# After
+global:
+  image:
+    registry: artifactory.devops.telekom.de
+    namespace: mcicd-internal-oci/tardis/components/gateway
+```
+
+If you rely on the chart's default image references (rather than overriding `global.image.registry`/`namespace`
+explicitly), your deployment will start pulling from Artifactory instead of MTR. This is not a schema/API
+change (no key renames), so it does not require a major version bump, but it is a behavior change worth
+reviewing before upgrading — especially if your cluster cannot reach `artifactory.devops.telekom.de`.
+
+### Pull Credentials
+
+The default registry host, `artifactory.devops.telekom.de`, requires an image pull secret. The credentials do
+not need special repository permissions; any Artifactory service account that can authenticate to the untrusted
+Artifactory endpoint is sufficient because the `mcicd-internal-oci` mirror is readable by authenticated users.
+
+If your cluster is part of the DTAG Hitnet, you can avoid pull secrets by overriding only the registry host and
+using the trusted Artifactory endpoint:
+
+```yaml
+global:
+  image:
+    registry: trusted.artifactory.devops.telekom.de
+```
+
+### Component Image Names
+
+Component-level `repository` defaults were also renamed to match the new Artifactory image names, so a single
+global namespace override remains sufficient (no per-image `repository` overrides required):
+
+| Component | Old `repository` default | New `repository` default |
+| - | - | - |
+| Kong | `gateway-kong` | `kong` |
+| Jumper | `gateway-jumper` | `jumper` |
+| Issuer Service | `gateway-issuer-service-go` | `issuer-service` |
+| Circuitbreaker | `gateway-circuitbreaker` | `circuitbreaker-service` |
+
+### Third-Party Image Defaults
+
+Third-party image defaults changed too (cosign kept at the same version, only the registry path changed):
+
+| Image | Old default | New default |
+| - | - | - |
+| PostgreSQL | `eu_it_co_development/o28m/postgresql:16.5` | `hub.docker.com/postgres:16-alpine` (Artifactory remote repo) |
+| cosign (`imageVerification.image`) | `eu_it_co_development/o28m/cosign:v2.5.3` | `mcicd-internal-oci/tardis/infra/components/ghcr.io.docker/sigstore/cosign/cosign:v2.5.3` |
+| curl (`job.image`) | `eu_it_co_development/o28m/bash-curl:8.13.0` | `mcicd-internal-oci/tardis/infra/components/helper/curl:8.17.0-r1` |
+
 ## From 8.x.x to 9.x.x
+
 
 Version 9.0.0 introduces several breaking changes that modernize the chart structure and align with Kubernetes best practices. Review all changes carefully before upgrading.
 

--- a/values.yaml
+++ b/values.yaml
@@ -27,12 +27,12 @@ global:
 
   # Default image configuration (can be overridden per component)
   # Images are constructed as: {registry}/{namespace}/{repository}:{tag}
-  # Example: mtr.devops.telekom.de/eu_it_co_development/o28m/gateway-kong:1.1.0
+  # Example: artifactory.devops.telekom.de/mcicd-internal-oci/tardis/components/gateway/kong:1.7.0
   image:
     # -- Default image registry
-    registry: mtr.devops.telekom.de
+    registry: artifactory.devops.telekom.de
     # -- Default image namespace
-    namespace: eu_it_co_development/o28m
+    namespace: mcicd-internal-oci/tardis/components/gateway
 
   # -- Array of pull secret names for image pulling
   imagePullSecrets: []
@@ -126,7 +126,7 @@ templateChangeTriggers: []
 image:
   # registry: ""  # Override global.image.registry
   # namespace: ""  # Override global.image.namespace
-  repository: gateway-kong
+  repository: kong
   # -- Kong Gateway image tag
   tag: "1.7.1"
 
@@ -874,7 +874,7 @@ jumper:
   image:
     # registry: ""  # Override global.image.registry
     # namespace: ""  # Override global.image.namespace
-    repository: gateway-jumper
+    repository: jumper
     tag: "4.12.0"
 
   # -- Image pull policy for Jumper container
@@ -1002,7 +1002,7 @@ issuerService:
   image:
     # registry: ""  # Override global.image.registry
     # namespace: ""  # Override global.image.namespace
-    repository: gateway-issuer-service-go
+    repository: issuer-service
     tag: "2.3.4"
 
   # -- Image pull policy for Issuer Service container
@@ -1069,7 +1069,7 @@ circuitbreaker:
   image:
     # registry: ""  # Override global.image.registry
     # namespace: ""  # Override global.image.namespace
-    repository: gateway-circuitbreaker
+    repository: circuitbreaker-service
     tag: "2.1.0"
 
   # -- Image pull policy for circuit breaker container
@@ -1103,12 +1103,13 @@ circuitbreaker:
 
 # PostgreSQL database configuration
 postgresql:
-  # -- PostgreSQL image configuration (inherits from global.image)
+  # -- PostgreSQL image configuration (Artifactory hub.docker.com remote repo, does not inherit
+  # global.image.namespace; registry is inherited since it's the same Artifactory host)
   image:
     # registry: ""  # Override global.image.registry
-    # namespace: ""  # Override global.image.namespace
-    repository: postgresql
-    tag: "16.5"
+    namespace: hub.docker.com
+    repository: postgres
+    tag: "16-alpine"
 
   # -- Image pull policy for PostgreSQL container
   imagePullPolicy: IfNotPresent
@@ -1183,13 +1184,13 @@ externalDatabase:
   #  <CA certificate in PEM format>
   #  -----END CERTIFICATE-----
 
-# -- Job image configuration for setup jobs (inherits from global.image)
+# -- Job image configuration for setup jobs (curl helper image, does not inherit global.image namespace)
 job:
   image:
     # registry: ""  # Override global.image.registry
-    # namespace: ""  # Override global.image.namespace
-    repository: bash-curl
-    tag: "8.13.0"
+    namespace: mcicd-internal-oci/tardis/infra/components/helper
+    repository: curl
+    tag: "8.17.0-r1"
 
 # Automatic certificate/key rotation (requires cert-manager and gateway-rotator)
 # Alternative: use jumper.existingJwkSecretName and issuerService.existingJwkSecretName
@@ -1230,10 +1231,10 @@ imageVerification:
   # -- Verification mode: "enforce" (block pod on invalid signature) or "audit" (log and continue)
   mode: enforce
 
-  # -- Cosign image configuration (inherits from global.image)
+  # -- Cosign image configuration (does not inherit global.image namespace)
   image:
     # registry: ""  # Override global.image.registry
-    # namespace: ""  # Override global.image.namespace
+    namespace: mcicd-internal-oci/tardis/infra/components/ghcr.io.docker/sigstore/cosign
     repository: cosign
     tag: "v2.5.3"
 


### PR DESCRIPTION
## Summary

Migrates the chart's default image references from the legacy MTR registry to Artifactory. We push images to `tardis-oci-local` (our own service account), which is mirrored automatically into `mcicd-internal-oci` — readable by any authenticated Artifactory user. Chart defaults read from `mcicd-internal-oci`, so no dedicated NatCo service account or pull secret is required for chart-default consumers.

## Changes

### Gateway-owned images
- `global.image.registry`: `mtr.devops.telekom.de` → `artifactory.devops.telekom.de`
- `global.image.namespace`: `eu_it_co_development/o28m` → `mcicd-internal-oci/tardis/components/gateway`
- Per-image `repository` defaults renamed to match the new Artifactory layout, so the global namespace override alone is sufficient (no per-image repository overrides needed downstream):
  | Component | Old | New |
  |---|---|---|
  | Kong | `gateway-kong` | `kong` |
  | Jumper | `gateway-jumper` | `jumper` |
  | Issuer Service | `gateway-issuer-service-go` | `issuer-service` |
  | Circuit Breaker | `gateway-circuitbreaker` | `circuitbreaker-service` |

### Third-party images (explicitly repointed so they do not silently inherit the new global namespace)
- `postgresql` → Artifactory's `hub.docker.com` remote repo: `artifactory.devops.telekom.de/hub.docker.com/postgres:16-alpine` (previously `postgresql:16.5` on MTR). Standardizing on `16-alpine` is safe — all gateway databases run PostgreSQL 16.11.
  - Note: this deliberately targets Artifactory's `hub.docker.com` remote repository, **not** `dockerhub.devops.telekom.de` — that legacy mirror is being decommissioned (~EOL September 2026).
- `job` (bash-curl) → curl helper image: `mcicd-internal-oci/tardis/infra/components/helper/curl:8.17.0-r1`
- `imageVerification` (cosign) → `mcicd-internal-oci/tardis/infra/components/ghcr.io.docker/sigstore/cosign/cosign:v2.5.3` (registry/namespace only — version unchanged)

### Docs
- Updated the image-configuration example in `README.md.gotmpl` to reflect the new registry/namespace/repository/tag.
- Regenerated `README.md` via `helm-docs`.

## Verification
- `helm lint .` — passes (pre-existing INFO-level warnings only, unrelated to this change)
- `helm template` — confirmed all 9 image references render with the expected registry/namespace/repository/tag combinations, including the third-party overrides.

## Not in scope
- ArgoCD cfg files (`argocd/Apps/stargate/**`) are a separate, staged rollout (internal → customer → production) and are not part of this PR.
- `roverctl` is out of scope, migrated separately by the Rover team.