### PR TITLE
fix: add resource limits to Kong bootstrap and migration jobs

### DIFF
--- a/templates/jobs/kong/bootstrap.yml
+++ b/templates/jobs/kong/bootstrap.yml
@@ -23,6 +23,7 @@ spec:
         image: '{{ include "images.postgresql" $ }}'
         imagePullPolicy: {{ .Values.postgresql.imagePullPolicy | default .Values.global.imagePullPolicy }}
         securityContext: {{ .Values.postgresql.containerSecurityContext | toYaml | nindent 10 }}
+        resources: {{ .Values.setupJobs.resources | toYaml | nindent 10 }}
         command: ['/bin/bash']
         args: ['-c', 'until pg_isready -U {{ .Values.global.database.username }}; do echo waiting for database; sleep 2; done;']
         env:
@@ -32,6 +33,7 @@ spec:
         image: {{ include "images.kong" $ }}
         imagePullPolicy: {{ .Values.imagePullPolicy | default .Values.global.imagePullPolicy }}
         securityContext: {{ .Values.containerSecurityContext | toYaml | nindent 10 }}
+        resources: {{ .Values.setupJobs.resources | toYaml | nindent 10 }}
         env:
         {{- include "kong.migrations.env" $ | indent 8 }}
         command: [ "/bin/sh", "-c", "KONG_NGINX_DAEMON='off' kong migrations bootstrap" ]

--- a/templates/jobs/kong/migrations-up.yml
+++ b/templates/jobs/kong/migrations-up.yml
@@ -26,6 +26,7 @@ spec:
         image: '{{ include "images.postgresql" $ }}'
         imagePullPolicy: {{ .Values.postgresql.imagePullPolicy | default .Values.global.imagePullPolicy }}
         securityContext: {{ .Values.postgresql.containerSecurityContext | toYaml | nindent 10 }}
+        resources: {{ .Values.setupJobs.resources | toYaml | nindent 10 }}
         command: ['/bin/bash']
         args: ['-c', 'until pg_isready -U {{ .Values.global.database.username }}; do echo waiting for database; sleep 2; done;']
         env:
@@ -35,6 +36,7 @@ spec:
         image: {{ include "images.kong" $ }}
         imagePullPolicy: {{ .Values.imagePullPolicy | default .Values.global.imagePullPolicy }}
         securityContext: {{ .Values.containerSecurityContext | toYaml | nindent 10 }}
+        resources: {{ .Values.setupJobs.resources | toYaml | nindent 10 }}
         env:
         {{- include "kong.migrations.env" $ | indent 8 }}
         command: [ "/bin/sh", "-c", "KONG_NGINX_DAEMON='off' kong migrations up || true; KONG_NGINX_DAEMON='off' kong migrations finish" ]


### PR DESCRIPTION
Fixes #50

Added missing resource limit specifications to Kong bootstrap and migration job manifests to comply with Kubernetes best practices and prevent failures in environments with strict resource policies.

Changes:
- templates/jobs/kong/bootstrap.yml: Added resources to check-database initContainer and kong-bootstrap main container
- templates/jobs/kong/migrations-up.yml: Added resources to check-database initContainer and kong-upgrade-migrations main container

Both jobs now use the existing setupJobs.resources configuration:
- CPU request: 50m, limit: 500m
- Memory request: 200Mi, limit: 500Mi

This ensures consistency with other setup jobs in the chart and prevents job failures in clusters with ResourceQuota or LimitRange policies.