### PR TITLE
feat: bump gateway-jumper to 4.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,7 +815,7 @@ The following table provides a comprehensive list of all configurable parameters
 | jumper.enabled | bool | `true` | Enable Jumper container deployment |
 | jumper.environment | list | `[]` | Additional environment variables for Jumper container - {name: foo, value: bar} |
 | jumper.existingJwkSecretName | string | `nil` | Existing JWK secret name for OAuth token issuance (alternative to keyRotation.enabled=true) Must be compatible with gateway-rotator format: https://github.com/telekom/gateway-rotator#key-rotation-process |
-| jumper.image | object | `{"repository":"gateway-jumper","tag":"4.11.1"}` | Jumper image configuration (inherits from global.image) |
+| jumper.image | object | `{"repository":"gateway-jumper","tag":"4.12.0"}` | Jumper image configuration (inherits from global.image) |
 | jumper.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for Jumper container |
 | jumper.internetFacingZones | list | `[]` | List of zones that are considered internet-facing (empty list uses Jumper's default configuration) Example: [space, canis, aries] |
 | jumper.issuerUrl | string | `"https://<your-gateway-host>/auth/realms/default"` | Issuer service URL for gateway token issuance (your gateway's auth realm endpoint) |

--- a/values.yaml
+++ b/values.yaml
@@ -875,7 +875,7 @@ jumper:
     # registry: ""  # Override global.image.registry
     # namespace: ""  # Override global.image.namespace
     repository: gateway-jumper
-    tag: "4.11.1"
+    tag: "4.12.0"
 
   # -- Image pull policy for Jumper container
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary

- Bump the default gateway-jumper image tag from 4.11.1 to 4.12.0.
- Regenerate the README values table with helm-docs.

## Verification

- `helm lint .`