### PR TITLE
fix(cosign): verify images without credentials first

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,8 +616,8 @@ Disable this feature if you are using [Kyverno](https://kyverno.io/) or another 
 On each pod startup, the cosign InitContainer:
 
 1. Iterates over all enabled container images (Kong, Jumper, Issuer Service, Circuit Breaker)
-2. Authenticates to the image registry using the configured `imagePullSecrets`
-3. Verifies each image signature against the configured public key
+2. Verifies each image signature against the configured public key
+3. Falls back to configured `imagePullSecrets` only if the registry requires authentication
 4. Blocks pod startup if verification fails (in `enforce` mode) or logs a warning and continues (in `audit` mode)
 
 **Verification Modes:**

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -616,8 +616,8 @@ Disable this feature if you are using [Kyverno](https://kyverno.io/) or another 
 On each pod startup, the cosign InitContainer:
 
 1. Iterates over all enabled container images (Kong, Jumper, Issuer Service, Circuit Breaker)
-2. Authenticates to the image registry using the configured `imagePullSecrets`
-3. Verifies each image signature against the configured public key
+2. Verifies each image signature against the configured public key
+3. Falls back to configured `imagePullSecrets` only if the registry requires authentication
 4. Blocks pod startup if verification fails (in `enforce` mode) or logs a warning and continues (in `audit` mode)
 
 **Verification Modes:**

--- a/templates/_cosign.tpl
+++ b/templates/_cosign.tpl
@@ -154,6 +154,24 @@ Returns the InitContainer for cosign image verification.
       REGISTRY=$(echo "$IMAGE" | cut -d'/' -f1)
       IMAGE_PROCESSED=0
 
+      # Trusted/public registries do not need credentials. Try without login first.
+      # Only fall back to imagePullSecrets when the registry explicitly denies access.
+      rm -f "$DOCKER_CONFIG/config.json"
+      OUTPUT=$(cosign verify --insecure-ignore-tlog=true --key /cosign/{{ include "cosign.publicKeyFilename" . }} "$IMAGE" 2>&1)
+      EXIT_CODE=$?
+
+      if [ $EXIT_CODE -eq 0 ]; then
+        echo "✓ $IMAGE: signature valid"
+        IMAGE_PROCESSED=1
+        continue
+      elif ! echo "$OUTPUT" | grep -q "UNAUTHORIZED"; then
+        echo "✗ $IMAGE: signature verification FAILED"
+        echo "$OUTPUT"
+        FAILED=1
+        IMAGE_PROCESSED=1
+        continue
+      fi
+
       # Try each pull secret until verification succeeds
       for SECRET_DIR in /pull-secrets/*; do
         if [ -d "$SECRET_DIR" ]; then


### PR DESCRIPTION
## Summary

- Try cosign verification without registry login before using mounted `imagePullSecrets`.
- Keep the existing pull-secret fallback for registries that return `UNAUTHORIZED`.
- Update the image verification docs to describe the unauthenticated-first behavior.

## Why

Trusted/public registries can be readable without pull secrets. The previous init container logic only attempted `cosign verify` after finding matching credentials in `global.imagePullSecrets`, so verification failed with `UNAUTHORIZED with all available secrets` when no matching secret was present.

## Validation

- `helm lint .`
- `helm template test . --set imageVerification.enabled=true --set global.failOnUnsetValues=false --set jumper.existingJwkSecretName=dummy --set issuerService.existingJwkSecretName=dummy --show-only templates/deployment.yml`
