### PR TITLE
feat(jumper): support inline zoneHealth redis/valkey password via sel…

### DIFF
--- a/README.md
+++ b/README.md
@@ -834,8 +834,8 @@ The following table provides a comprehensive list of all configurable parameters
 | jumper.zoneHealth.databaseHost | string | `"localhost"` | Redis database hostname |
 | jumper.zoneHealth.databaseIndex | int | `2` | Redis database index |
 | jumper.zoneHealth.databasePort | int | `6379` | Redis database port |
-| jumper.zoneHealth.databaseSecretKey | string | `"redis-password"` | Secret key for Redis password |
-| jumper.zoneHealth.databaseSecretName | string | `"redis"` | Secret name containing Redis credentials |
+| jumper.zoneHealth.databaseSecretKey | string | `"redis-password"` | Key within the existing Secret that holds the Redis password (used only when databasePassword is not set) |
+| jumper.zoneHealth.databaseSecretName | string | `"redis"` | Name of an existing Secret containing the Redis password (used only when databasePassword is not set) |
 | jumper.zoneHealth.databaseTimeout | int | `500` | Redis operation timeout in milliseconds |
 | jumper.zoneHealth.defaultHealth | bool | `true` | Default health status when Redis is unavailable |
 | jumper.zoneHealth.enabled | bool | `false` | Enable zone health monitoring |

--- a/templates/_kong.tpl
+++ b/templates/_kong.tpl
@@ -520,7 +520,13 @@ global collectorUrl.
   value: {{ .Values.jumper.zoneHealth.databasePort | quote }}
 - name: ZONE_HEALTH_DATABASE_INDEX
   value: {{ .Values.jumper.zoneHealth.databaseIndex | quote }}
-{{- if and .Values.jumper.zoneHealth.databaseSecretName .Values.jumper.zoneHealth.databaseSecretKey }}
+{{- if .Values.jumper.zoneHealth.databasePassword }}
+- name: ZONE_HEALTH_DATABASE_PASSWORD
+  valueFrom:
+   secretKeyRef:
+    name: {{ .Release.Name }}
+    key: zoneHealthDatabasePassword
+{{- else if and .Values.jumper.zoneHealth.databaseSecretName .Values.jumper.zoneHealth.databaseSecretKey }}
 - name: ZONE_HEALTH_DATABASE_PASSWORD
   valueFrom:
    secretKeyRef:

--- a/templates/secret-kong.yml
+++ b/templates/secret-kong.yml
@@ -36,6 +36,11 @@ data:
 {{- else }}
 {{- $unsetValues = append $unsetValues "databasePassword" }}
 {{- end }}
+{{- if .Values.jumper.zoneHealth.databasePassword }}
+  {{- /* Valkey/Redis credential is provisioned externally (not managed by this
+       chart), so password rule validation is intentionally not applied here. */}}
+  zoneHealthDatabasePassword: {{ .Values.jumper.zoneHealth.databasePassword | b64enc | quote }}
+{{- end }}
 {{- if and .Values.global.failOnUnsetValues (gt (len $unsetValues) 0) }}
 {{- fail (printf "Values not set in %s: %v" $name $unsetValues) }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -957,9 +957,18 @@ jumper:
     keyChannel: stargate-zone-status
     # -- Maximum request rate per second
     requestRate: 10000
-    # -- Secret name containing Redis credentials
+    # -- Redis password (optional). When set, the chart creates and manages its
+    # own Secret entry (key `zoneHealthDatabasePassword` in the release Secret)
+    # and injects it into Jumper. This takes precedence over
+    # databaseSecretName/databaseSecretKey and removes the dependency on an
+    # externally-managed Secret. Leave unset to reference an existing Secret via
+    # databaseSecretName/databaseSecretKey instead.
+    #databasePassword: ""
+    # -- Name of an existing Secret containing the Redis password (used only when
+    # databasePassword is not set)
     databaseSecretName: redis
-    # -- Secret key for Redis password
+    # -- Key within the existing Secret that holds the Redis password (used only
+    # when databasePassword is not set)
     databaseSecretKey: redis-password
     # -- Enable zone health monitoring
     enabled: false


### PR DESCRIPTION
support inline zoneHealth redis/valkey password via self-managed secret.

Add optional jumper.zoneHealth.databasePassword. When set, the chart stores it under `zoneHealthDatabasePassword` in the release Secret and wires it into Jumper's ZONE_HEALTH_DATABASE_PASSWORD, taking precedence over databaseSecretName/databaseSecretKey. This removes the dependency on an externally-managed Secret while remaining backward compatible: when the value is unset, the existing secret reference is used unchanged. Password rule validation (global.passwordRules) is intentionally not applied to this value, as the Redis/Valkey credential is provisioned and owned externally, not by this chart.