### PR TITLE
fix(jumper): restore one-way mesh compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,7 +815,7 @@ The following table provides a comprehensive list of all configurable parameters
 | jumper.enabled | bool | `true` | Enable Jumper container deployment |
 | jumper.environment | list | `[]` | Additional environment variables for Jumper container - {name: foo, value: bar} |
 | jumper.existingJwkSecretName | string | `nil` | Existing JWK secret name for OAuth token issuance (alternative to keyRotation.enabled=true) Must be compatible with gateway-rotator format: https://github.com/telekom/gateway-rotator#key-rotation-process |
-| jumper.image | object | `{"repository":"jumper","tag":"4.12.1"}` | Jumper image configuration (inherits from global.image) |
+| jumper.image | object | `{"repository":"jumper","tag":"4.12.3"}` | Jumper image configuration (inherits from global.image) |
 | jumper.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for Jumper container |
 | jumper.internetFacingZones | list | `[]` | List of zones that are considered internet-facing (empty list uses Jumper's default configuration) Example: [space, canis, aries] |
 | jumper.issuerUrl | string | `"https://<your-gateway-host>/auth/realms/default"` | Issuer service URL for gateway token issuance (your gateway's auth realm endpoint) |

--- a/values.yaml
+++ b/values.yaml
@@ -880,7 +880,7 @@ jumper:
     # registry: ""  # Override global.image.registry
     # namespace: ""  # Override global.image.namespace
     repository: jumper
-    tag: "4.12.1"
+    tag: "4.12.3"
 
   # -- Image pull policy for Jumper container
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary

Default the chart to Jumper 4.12.3.

Jumper 4.12.3 restores provider-zone IdP authentication for mesh calls, forwards the original token as `consumer-token`, and removes the provider-to-consumer JWK-set connectivity requirement.

## Dependency

Blocked by https://github.com/telekom/gateway-jumper/pull/159.

Keep this PR as a draft until that PR is merged and Jumper 4.12.3 is published.

## Changes

- update `jumper.image.tag` from `4.12.1` to `4.12.3`
- regenerate the chart parameter documentation

## Verification

- `helm lint .`
- `helm-docs`
- generated README remains current after regeneration
- `git diff --check`

## Release Note

The chart now defaults to Jumper 4.12.3. Mesh calls once again obtain a token from the provider zone's identity provider and require only consumer-to-provider connectivity. Mesh LMS will return as a breaking change in Jumper 5 and chart 10.
