### PR TITLE
Update Jumper image tag to 4.14.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,7 +815,7 @@ The following table provides a comprehensive list of all configurable parameters
 | jumper.enabled | bool | `true` | Enable Jumper container deployment |
 | jumper.environment | list | `[]` | Additional environment variables for Jumper container - {name: foo, value: bar} |
 | jumper.existingJwkSecretName | string | `nil` | Existing JWK secret name for OAuth token issuance (alternative to keyRotation.enabled=true) Must be compatible with gateway-rotator format: https://github.com/telekom/gateway-rotator#key-rotation-process |
-| jumper.image | object | `{"repository":"jumper","tag":"4.14.0"}` | Jumper image configuration (inherits from global.image) |
+| jumper.image | object | `{"repository":"jumper","tag":"4.14.1"}` | Jumper image configuration (inherits from global.image) |
 | jumper.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for Jumper container |
 | jumper.internetFacingZones | list | `[]` | List of zones that are considered internet-facing (empty list uses Jumper's default configuration) Example: [space, canis, aries] |
 | jumper.issuerUrl | string | `"https://<your-gateway-host>/auth/realms/default"` | Issuer service URL for gateway token issuance (your gateway's auth realm endpoint) |

--- a/values.yaml
+++ b/values.yaml
@@ -880,7 +880,7 @@ jumper:
     # registry: ""  # Override global.image.registry
     # namespace: ""  # Override global.image.namespace
     repository: jumper
-    tag: "4.14.0"
+    tag: "4.14.1"
 
   # -- Image pull policy for Jumper container
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Points the chart at the current stable Jumper release.

4.14.1 carries the automatic release workflow only. The runtime behaviour is unchanged from 4.14.0, so this is a version bump rather than a functional change.

`README.md` is regenerated by helm-docs, so the values table matches the new tag.

## Note on the release this produces

Merging publishes the first automatic chart release. It will include `c3274ef`, which is still unreleased: the workflows never ran for it, because its commit message quotes the CI skip token in prose and GitHub matched it literally. That is a message problem, not a workflow problem, and this merge is unaffected.
