### PR TITLE
Promote Mesh LMS to a stable release

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,7 +4,7 @@
 
 apiVersion: v2
 name: stargate
-version: 9.13.1
+version: 10.0.0-rc.1
 description: Kong API gateway provided by o28m
 maintainers:
 - name: Deutsche Telekom AG

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ helm install my-gateway . -f my-values.yaml
 - **Kubernetes Cluster**
 - **Helm**: Version 3.x
 - **Ingress Controller**: NGINX Ingress Controller (or compatible alternative) for external access
+- **Zone connectivity**: if you run a gateway mesh, each provider zone must be able to reach the Issuer Service of every zone that sends it mesh traffic. A mesh call is signed by the consumer gateway, and the provider gateway validates it by retrieving that gateway's JWK set. See [UPGRADE.md](UPGRADE.md) if you are coming from a 9.x.x chart.
 
 ### Container Images
 
@@ -815,7 +816,7 @@ The following table provides a comprehensive list of all configurable parameters
 | jumper.enabled | bool | `true` | Enable Jumper container deployment |
 | jumper.environment | list | `[]` | Additional environment variables for Jumper container - {name: foo, value: bar} |
 | jumper.existingJwkSecretName | string | `nil` | Existing JWK secret name for OAuth token issuance (alternative to keyRotation.enabled=true) Must be compatible with gateway-rotator format: https://github.com/telekom/gateway-rotator#key-rotation-process |
-| jumper.image | object | `{"repository":"jumper","tag":"4.14.0"}` | Jumper image configuration (inherits from global.image) |
+| jumper.image | object | `{"repository":"jumper","tag":"5.0.0-rc.1"}` | Jumper image configuration (inherits from global.image) |
 | jumper.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for Jumper container |
 | jumper.internetFacingZones | list | `[]` | List of zones that are considered internet-facing (empty list uses Jumper's default configuration) Example: [space, canis, aries] |
 | jumper.issuerUrl | string | `"https://<your-gateway-host>/auth/realms/default"` | Issuer service URL for gateway token issuance (your gateway's auth realm endpoint) |

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -46,6 +46,7 @@ helm install my-gateway . -f my-values.yaml
 - **Kubernetes Cluster**
 - **Helm**: Version 3.x
 - **Ingress Controller**: NGINX Ingress Controller (or compatible alternative) for external access
+- **Zone connectivity**: if you run a gateway mesh, each provider zone must be able to reach the Issuer Service of every zone that sends it mesh traffic. A mesh call is signed by the consumer gateway, and the provider gateway validates it by retrieving that gateway's JWK set. See [UPGRADE.md](UPGRADE.md) if you are coming from a 9.x.x chart.
 
 ### Container Images
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,35 @@ SPDX-License-Identifier: CC0-1.0
 
 This document provides guidance for upgrading between versions of the Gateway Helm chart.
 
+## From 9.x.x to 10.x.x
+
+### Introduction of Mesh LMS requires connectivity in both directions
+
+Jumper 5 changes how a gateway mesh call is authenticated. A consumer gateway now signs a short-lived
+Mesh LMS token itself, instead of fetching a token from the provider zone's identity provider. The
+provider gateway validates that token by retrieving the JWK set of the consumer gateway that signed
+it, from the consumer gateway's Issuer Service.
+
+Traffic between zones is therefore no longer one-way. Before this version:
+
+```
+consumer zone  ────────────────────>  provider zone
+```
+
+From this version:
+
+```
+consumer zone  ────────────────────>  provider zone
+consumer zone  <────  JWK set  ─────  provider zone
+```
+
+**Before upgrading, confirm that each provider zone can reach the Issuer Service of every zone that
+sends it mesh traffic.** A deployment that keeps one-way connectivity rejects mesh calls. Calls that
+do not cross zones are unaffected.
+
+Nothing in the chart enables or disables this. The requirement follows from the Jumper image, so it
+applies as soon as the new Jumper version runs, and it cannot be switched off through `values.yaml`.
+
 ## Default Image Registry Changed to Artifactory (9.11.0 and up)
 
 ### New Default Image Registry

--- a/values.yaml
+++ b/values.yaml
@@ -880,7 +880,7 @@ jumper:
     # registry: ""  # Override global.image.registry
     # namespace: ""  # Override global.image.namespace
     repository: jumper
-    tag: "4.14.0"
+    tag: "5.0.0-rc.1"
 
   # -- Image pull policy for Jumper container
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
This PR will promote the chart that activates Mesh LMS, currently released only as a release candidate, to a stable release. It is the chart counterpart to https://github.com/telekom/gateway-jumper/pull/165 and should be merged after it.

`next` currently pins Jumper `5.0.0-rc.1`. A stable chart must not pin a release candidate.

## Before merging: move the pin to the stable Jumper 5 image

Once Jumper 5 is released as stable, add a commit to `next` that moves the pin. Do not amend the existing commit, and do not change the pin in this pull request only — `next` publishes its own release candidates, so the change belongs on the branch:

1. Set `jumper.image.tag` in `values.yaml` to the stable Jumper 5 version.
2. Run `helm-docs` so the values table in `README.md` matches. Never edit `README.md` by hand.
3. Commit as `fix(jumper): pin the stable Mesh LMS release`. Do not repeat the `BREAKING CHANGE` footer — the breaking change is already recorded in `feat(jumper)!: pin the Mesh LMS release candidate`, and repeating it does not change the computed version.

That produces one more release candidate on `next`, which is the version this pull request then promotes to `10.0.0`.

## Upgrade documentation

`UPGRADE.md` describes only the connectivity requirement, which is true for the whole 10.x line. It deliberately says nothing about release candidates, so it can be promoted to stable unchanged.

## Before merging

Confirm that every change made to `main` after `next` was branched is present on `next`, and that a release candidate has been verified on customer-facing environments with connectivity established in both directions.

Merging publishes `10.0.0`. Delete `next` afterwards, and recreate it from `main` when a future prerelease line is needed.
